### PR TITLE
Release/0.7.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,12 +31,21 @@ jobs:
 
   build-android:
     name: Integration tests on Android
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v1
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+        
+      - name: Configure JDK
+        uses: actions/setup-java@v3
         with:
-          java-version: "11.x"
+          distribution: "temurin"
+          java-version: "17"
 
       # -- Micro --
       - name: Cache Micro
@@ -75,7 +84,7 @@ jobs:
 
   build-ios:
     name: Integration tests on iOS
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v4
 
@@ -100,11 +109,12 @@ jobs:
 
       # -- Integration tests --
       - name: "Start Simulator"
-        uses: futureware-tech/simulator-action@v1
+        uses: futureware-tech/simulator-action@v3
         with:
-          model: iPhone 13
+          model: iPhone 14 Pro Max
           erase_before_boot: true
           shutdown_after_job: true
+          os_version: 16.2
 
       - uses: subosito/flutter-action@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
+# 0.7.1
+
+* Automatically generate ID for ScreenViews (#55)
+
 # 0.7.0
 
-* Add media tracking APIs to the tracker (close #49)
+* Add media tracking APIs to the tracker (#49)
 * Fix tracker initialization with partial platform context property overrides on Android (#53)
 * Update uuid package constraint to 4.0.0 (#48) thanks to @petermnt
-* Add support for Android Gradle Plugin 8 (close #46) thanks to @petermnt
+* Add support for Android Gradle Plugin 8 (#46) thanks to @petermnt
 * Remove documentation in the project in favour of docs.snowplow.io to reduce duplicity (#51)
 * Update flutter_lints, http, js, and example dependency versions (#52)
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This will add a line with the dependency like this to your `pubspec.yaml`:
 
 ```yml
 dependencies:
-    snowplow_tracker: ^0.7.0
+    snowplow_tracker: ^0.7.1
 ```
 
 Import the package into your Dart code:

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Running the integration tests on Android/iOS:
 2. Run the integration tests (replace the Snowplow Micro URI with your IP address and set your iPhone or Android simulator name or remove to use default):
 
 ```bash
-flutter test integration_test --dart-define=ENDPOINT=http://192.168.100.127:9090 -d "iPhone 13 Pro"
+flutter test integration_test --dart-define=ENDPOINT=http://192.168.0.20:9090 -d "iPhone 13 Pro"
 ```
 
 Alternatively, you may also run the integration tests directly from Visual Studio Code.

--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/TrackerVersion.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/TrackerVersion.kt
@@ -12,5 +12,5 @@
 package com.snowplowanalytics.snowplow_tracker
 
 object TrackerVersion {
-    val TRACKER_VERSION = "flutter-0.7.0"
+    val TRACKER_VERSION = "flutter-0.7.1"
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - snowplow_tracker (0.7.0):
+  - snowplow_tracker (0.7.1):
     - Flutter
     - SnowplowTracker (~> 6.0.2)
   - SnowplowTracker (6.0.2)
@@ -26,8 +26,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  integration_test: 13825b8a9334a850581300559b8839134b124670
-  snowplow_tracker: 7951e14a4c8c17de35ad58eaac17dd51efda054d
+  integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
+  snowplow_tracker: 0236afd8fee445e9e018a0d0111e41e64d9e9ad3
   SnowplowTracker: e53f7eb7de911801b741af2bd9e079e091fa7f2b
 
 PODFILE CHECKSUM: c4c93c5f6502fe2754f48404d3594bf779584011

--- a/example/lib/main_page.dart
+++ b/example/lib/main_page.dart
@@ -119,10 +119,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
             ElevatedButton(
               onPressed: () {
                 const event = ScreenView(
-                    id: '2c295365-eae9-4243-a3ee-5c4b7baccc8f',
-                    name: 'home',
-                    type: 'full',
-                    transitionType: 'none');
+                    name: 'home', type: 'full', transitionType: 'none');
                 trackEvent(event);
               },
               child: const Text('Send Screen View Event'),

--- a/example/lib/overview.dart
+++ b/example/lib/overview.dart
@@ -27,7 +27,7 @@ This will add a line with the dependency like this to your `pubspec.yaml`:
 
 ```yml
 dependencies:
-    snowplow_tracker: ^0.7.0
+    snowplow_tracker: ^0.7.1
 ```
 
 Import the package into your Dart code:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: args
-      sha256: eef6c46b622e0494a36c5a12d10d77fb4e855501a91c1b9ef9339326e58f0596
+      sha256: "7cf60b9f0cc88203c5a190b4cd62a99feea42759a7fa695010eb5de1c0b2252a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   async:
     dependency: transitive
     description:
@@ -61,10 +61,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.6"
+    version: "1.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -111,10 +111,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_markdown
-      sha256: "31c12de79262b5431c5492e9c89948aa789158435f707d3519a7fdef6af28af7"
+      sha256: "5b24061317f850af858ef7151dadbb6eb77c1c449c954c7bb064e8a5e0e7d81f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.22+1"
+    version: "0.6.20"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -163,26 +163,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -219,10 +219,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   path:
     dependency: transitive
     description:
@@ -319,10 +319,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -335,10 +335,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: cd210a09f7c18cbe5a02511718e0334de6559871052c90a90c0cca46a4aa81c8
+      sha256: "814e9e88f21a176ae1359149021870e87f7cddaf633ab678a5d2b0bff7fd1ba8"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.3"
+    version: "4.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -351,10 +351,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:
@@ -373,4 +373,4 @@ packages:
     version: "3.0.3"
 sdks:
   dart: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -258,7 +258,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.7.1"
   source_span:
     dependency: transitive
     description:

--- a/ios/Classes/TrackerVersion.swift
+++ b/ios/Classes/TrackerVersion.swift
@@ -12,5 +12,5 @@
 import Foundation
 
 class TrackerVersion {
-    static let TRACKER_VERSION = "flutter-0.7.0"
+    static let TRACKER_VERSION = "flutter-0.7.1"
 }

--- a/ios/snowplow_tracker.podspec
+++ b/ios/snowplow_tracker.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'snowplow_tracker'
-  s.version          = '0.7.0'
+  s.version          = '0.7.1'
   s.summary          = 'A package for tracking Snowplow events in Flutter apps.'
   s.description      = <<-DESC
 A package for tracking Snowplow events in Flutter apps.

--- a/lib/events/screen_view.dart
+++ b/lib/events/screen_view.dart
@@ -23,7 +23,7 @@ class ScreenView implements Event {
   final String name;
 
   /// The id (UUID v4) of screen that was viewed.
-  final String id;
+  final String? id;
 
   /// The type of screen that was viewed.
   final String? type;
@@ -42,7 +42,7 @@ class ScreenView implements Event {
 
   const ScreenView(
       {required this.name,
-      required this.id,
+      this.id,
       this.type,
       this.previousName,
       this.previousType,

--- a/lib/src/web/readers/events/screen_view_reader.dart
+++ b/lib/src/web/readers/events/screen_view_reader.dart
@@ -10,6 +10,7 @@
 // See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 
 import 'package:snowplow_tracker/events/screen_view.dart';
+import 'package:uuid/uuid.dart';
 import 'event_reader.dart';
 
 class ScreenViewReader extends ScreenView implements EventReader {
@@ -23,6 +24,13 @@ class ScreenViewReader extends ScreenView implements EventReader {
             previousId: map['previousId'],
             transitionType: map['transitionType']);
 
+  String? idUUID() {
+    if (id == null) {
+      return const Uuid().v4();
+    }
+    return id;
+  }
+
   @override
   String endpoint() {
     return 'trackSelfDescribingEvent';
@@ -32,7 +40,7 @@ class ScreenViewReader extends ScreenView implements EventReader {
   Map eventData() {
     var data = {
       'name': name,
-      'id': id,
+      'id': idUUID(),
       'type': type,
       'previousName': previousName,
       'previousId': previousId,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.2
+  flutter_lints: ^4.0.0
   http: "1.2.0"
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: snowplow_tracker
 description: A package for tracking Snowplow events in Flutter apps
-version: 0.7.0
+version: 0.7.1
 homepage: https://github.com/snowplow/snowplow-flutter-tracker
 repository: https://github.com/snowplow/snowplow-flutter-tracker
 

--- a/test/snowplow_test.dart
+++ b/test/snowplow_test.dart
@@ -12,7 +12,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:snowplow_tracker/snowplow_tracker.dart';
-import 'package:uuid/uuid.dart';
 
 void main() {
   const MethodChannel channel = MethodChannel('snowplow_tracker');
@@ -195,15 +194,14 @@ void main() {
   });
 
   test('tracks screen view event', () async {
-    String id = const Uuid().v4();
-    Event event = ScreenView(name: 'screen1', id: id);
+    Event event = const ScreenView(name: 'screen1');
     await Snowplow.track(event, tracker: 'tns2');
 
     expect(
         methodCall,
         isMethodCall('trackScreenView', arguments: {
           'tracker': 'tns2',
-          'eventData': {'name': 'screen1', 'id': id}
+          'eventData': {'name': 'screen1'}
         }));
   });
 


### PR DESCRIPTION
This patch release removes the requirement for the user to provide an ID for `ScreenView` events.

In `ScreenView` events (for mobile), the ID is a UUID that represents that specific loading of that screen. This ID was mistakenly set as a required argument for `ScreenView`s. The tracker will generate an ID by itself, although this can still be overriden by providing an ID as argument.

## Bug fixes
- Automatically generate ID for ScreenViews (#55) 