### PR TITLE
ci: add implement + claude-code workflows for the agent pipeline

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,78 @@
+name: Claude Code
+
+# Responds to `@claude` mentions in PR / issue comments and review threads.
+#
+# Primary use case: amending an in-flight PR during review — engineers
+# comment with corrections, follow-up scope changes, or answers to
+# questions raised by the bot's draft PR, and tag `@claude`. The bot
+# pulls the PR context, makes the requested change on the same branch,
+# and replies inline.
+#
+# Mirrors the equivalent workflow in `signals-monorepo` (and the other
+# Snowplow agent-toolable repos), using the same `snowplow-claude-review`
+# GitHub App.
+#
+# Required secrets (org-inherited from snowplow):
+#   - CLAUDE_REVIEW_APP_ID
+#   - CLAUDE_REVIEW_APP_PRIVATE_KEY
+# Required secrets (repo):
+#   - ANTHROPIC_API_KEY
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      github.event.sender.type != 'Bot' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_REVIEW_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          additional_permissions: |
+            actions: read
+          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue comment:*),Bash(flutter:*),Bash(dart:*)"'

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -8,13 +8,11 @@ name: Claude Code
 # pulls the PR context, makes the requested change on the same branch,
 # and replies inline.
 #
-# Mirrors the equivalent workflow in `signals-monorepo` (and the other
-# Snowplow agent-toolable repos), using the same `snowplow-claude-review`
-# GitHub App.
+# Auth: uses the default `GITHUB_TOKEN` because the
+# `snowplow-claude-review` GitHub App is only installed on
+# `snowplow-incubator`. See the comment in implement.yml for the
+# trade-off.
 #
-# Required secrets (org-inherited from snowplow):
-#   - CLAUDE_REVIEW_APP_ID
-#   - CLAUDE_REVIEW_APP_PRIVATE_KEY
 # Required secrets (repo):
 #   - ANTHROPIC_API_KEY
 
@@ -47,17 +45,9 @@ jobs:
       actions: read
 
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
-          private-key: ${{ secrets.CLAUDE_REVIEW_APP_PRIVATE_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
 
       - name: Set up Flutter
@@ -72,7 +62,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           additional_permissions: |
             actions: read
           claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue comment:*),Bash(flutter:*),Bash(dart:*)"'

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -13,9 +13,14 @@ name: Implement
 #   - opens a draft PR with `Closes #NNN` in the body,
 #   - replies on the issue with the PR URL.
 #
-# Required secrets (org-inherited from snowplow):
-#   - CLAUDE_REVIEW_APP_ID
-#   - CLAUDE_REVIEW_APP_PRIVATE_KEY
+# Auth: uses the default `GITHUB_TOKEN` because the
+# `snowplow-claude-review` GitHub App is only installed on
+# `snowplow-incubator`. A side-effect: PRs Claude opens here won't
+# auto-trigger downstream CI workflows (GitHub filters bot-authored
+# events from the default token to prevent recursion). If we ever
+# install the App on this org we can swap back to an App-minted token
+# and downstream CI will fire automatically.
+#
 # Required secrets (repo):
 #   - ANTHROPIC_API_KEY
 
@@ -36,19 +41,9 @@ jobs:
       actions: read
 
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
-          private-key: ${{ secrets.CLAUDE_REVIEW_APP_PRIVATE_KEY }}
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Use the app token so branches/PRs Claude creates trigger downstream
-          # CI (the default GITHUB_TOKEN would suppress those workflows).
-          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Set up Flutter
@@ -63,7 +58,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           additional_permissions: |
             actions: read
           claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue comment:*),Bash(flutter:*),Bash(dart:*)"'

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -61,4 +61,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           additional_permissions: |
             actions: read
+          # The `implement` label on this issue IS the trigger. Without
+          # this the action looks for `@claude` in the body, finds
+          # nothing, and exits silently.
+          label_trigger: implement
+          # The dispatching issue is authored by the snowplow-claude-review
+          # GitHub App. Without this opt-in the action filters bot-authored
+          # events to prevent recursion.
+          allowed_bots: '*'
           claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue comment:*),Bash(flutter:*),Bash(dart:*)"'

--- a/.github/workflows/implement.yml
+++ b/.github/workflows/implement.yml
@@ -1,0 +1,69 @@
+name: Implement
+
+# Triggered when the `implement` label is added to a GitHub issue.
+#
+# Issues come from the refine-agent dispatcher (in
+# `snowplow-incubator/refine-agent`), which builds a self-contained body
+# carrying the relevant slice of the merged plan. This workflow hands
+# the issue context to `anthropics/claude-code-action`, which:
+#
+#   - reads the issue title and body as the spec,
+#   - reads CLAUDE.md (including the "Implementing tickets" section),
+#   - implements the change with `flutter` / `dart` for build / test,
+#   - opens a draft PR with `Closes #NNN` in the body,
+#   - replies on the issue with the PR URL.
+#
+# Required secrets (org-inherited from snowplow):
+#   - CLAUDE_REVIEW_APP_ID
+#   - CLAUDE_REVIEW_APP_PRIVATE_KEY
+# Required secrets (repo):
+#   - ANTHROPIC_API_KEY
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  implement:
+    if: github.event.label.name == 'implement'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_REVIEW_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_REVIEW_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # Use the app token so branches/PRs Claude creates trigger downstream
+          # CI (the default GITHUB_TOKEN would suppress those workflows).
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          additional_permissions: |
+            actions: read
+          claude_args: '--allowedTools "Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh issue comment:*),Bash(flutter:*),Bash(dart:*)"'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,6 +340,31 @@ testWidgets('end-to-end tracking', (tester) async {
 - [ ] Maps to native tracker methods
 - [ ] Consistent error handling
 
+## Implementing tickets
+
+When you're triggered by the `implement` label on a GitHub issue (or asked to implement an issue locally), the issue body is the spec — read it carefully before anything else.
+
+Then:
+
+1. Read this file. If the change is contained to one layer (Dart API, platform channels, Android/iOS/web bridges), match that layer's existing patterns before editing.
+2. Implement the change as described in the issue body. Don't deviate from its file-level intent. If you find an error in it, note the deviation in the PR description.
+3. Keep changes minimal and focused. Don't refactor unrelated code.
+4. Add or modify tests for every new feature or bug fix.
+5. If you discover a real architectural blocker the spec didn't anticipate, stop and post a comment on the issue. Don't guess.
+
+Before opening the PR:
+
+- `flutter analyze` — static analysis clean
+- `flutter test` — unit tests pass
+- `dart format lib test example/lib` — formatting consistent
+
+PR shape (matches this repo's `CONTRIBUTING.md`):
+
+- **Branch**: descriptive name (e.g. `fix/platform-channel-null-handling`).
+- **Commits**: `Description (closes #1234)` — 1-to-1 with the issue.
+- **PR title**: short, descriptive, with `(closes #1234)` referencing the issue.
+- **PR body**: explain why the change is needed, not just what it is. Single feature/fix per PR.
+
 ## Contributing to CLAUDE.md
 
 When adding or updating content in this document, please follow these guidelines:


### PR DESCRIPTION
## Summary

Adds the two CI workflows that wire this repo into the Snowplow agent pipeline:

1. **`implement.yml`** — fires on `issues:labeled` with `implement`. Issues come from the refine-agent dispatcher in [refine-agent](https://github.com/snowplow-incubator/refine-agent), which builds a self-contained issue body from the merged plan. The workflow picks it up and opens a draft PR.
2. **`claude-code.yml`** — responds to `@claude` mentions in PR / issue comments and review threads. Lets engineers ask the bot for inline amendments to an in-flight PR.

Same shape as the equivalent workflows in `signals-monorepo`. Flutter tracker build system: **flutter + dart**.

## Auth

Uses the default `secrets.GITHUB_TOKEN` rather than minting a token from the `snowplow-claude-review` GitHub App. The App's secrets only exist on the `snowplow-incubator` org, not on `snowplow` where this repo lives, so a token-mint would 401 at runtime.

Trade-off: PRs the bot opens won't auto-trigger downstream CI workflows (GitHub filters bot-authored events from the default token to prevent recursion). Re-run them manually if needed. If the App is later installed on the `snowplow` org and `CLAUDE_REVIEW_APP_*` secrets are provisioned there, we can swap back to an App-minted token in a one-line change per workflow.

## Changes

- **`.github/workflows/implement.yml`** (new) — checkout → build-system setup → `anthropics/claude-code-action` with the Flutter tracker's tool allowlist.
- **`.github/workflows/claude-code.yml`** (new) — same build-system setup, different trigger set (`issue_comment` / `pull_request_review_comment` / `pull_request_review` / `issues` with `@claude` in body).
- **`CLAUDE.md`** — new or extended with an "Implementing tickets" section matching this repo's existing `CONTRIBUTING.md` conventions.

## Required secret

| Name | Where it comes from |
|---|---|
| `ANTHROPIC_API_KEY` | Per-repo secret (needs to be added before either workflow works) |

## Test plan

- [ ] Lint: `yamllint` + `actionlint` (clean for both workflows).
- [ ] Confirm `ANTHROPIC_API_KEY` is set on the repo before merging.
- [ ] End-to-end `implement`: from refine-agent, dispatch an implement that touches this repo. Confirm a labelled GitHub issue appears here and the workflow opens a draft PR.
- [ ] End-to-end `@claude`: open a PR (any PR will do), comment `@claude please rename foo to bar`, confirm the bot makes the change on the branch.

## Related

- Template: `snowplow-incubator/signals-monorepo#533`.
- Dispatcher: [`snowplow-incubator/refine-agent`](https://github.com/snowplow-incubator/refine-agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)