### PR TITLE
Release 0.10.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build and Test
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 jobs:
   build:
     name: Run unit tests
@@ -84,7 +87,8 @@ jobs:
 
   build-ios:
     name: Integration tests on iOS
-    runs-on: macos-12
+    runs-on: macos-14
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -109,23 +113,35 @@ jobs:
 
       # -- Integration tests --
       - name: "Start Simulator"
-        uses: futureware-tech/simulator-action@v3
+        id: simulator
+        uses: futureware-tech/simulator-action@v4
         with:
-          model: iPhone 14 Pro Max
+          model: iPhone 15 Pro Max
           erase_before_boot: true
           shutdown_after_job: true
-          os_version: 16.2
 
+      # The iOS job pins a newer Flutter than the rest of the matrix
+      # (3.32.0): under 3.32.0 both `flutter drive` and `flutter test`
+      # stall while attaching to the iOS simulator, so the suite never
+      # starts. A newer SDK is required to attach reliably on the sim.
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.32.0'
+          flutter-version: '3.35.4'
           channel: 'stable'
 
       - run: "flutter clean"
 
+      # Target the simulator booted above explicitly via its UDID; the macOS
+      # runner image ships many simulators, so an unqualified `flutter test`
+      # cannot pick one.
       - name: Run tests
         working-directory: example
-        run: ./tool/e2e_tests.sh http://0.0.0.0:9090
+        run: |
+          for suite in configuration_test events_test session_test media_test; do
+            flutter test "integration_test/$suite.dart" \
+              -d "${{ steps.simulator.outputs.udid }}" \
+              --dart-define=ENDPOINT=http://127.0.0.1:9090
+          done
 
   build-web:
     name: Integration tests on Web

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 # 0.10.0
 * Add ability to toggle anonymous tracking at runtime via `setUserAnonymisation` and `setServerAnonymisation` (BCPF-2051)
 * Migrate web JS interop to `dart:js_interop` and `package:web`
+* Raise the minimum Flutter version to 3.19.0 (Dart 3.3.0)
 * Fix iOS integration tests in CI
 
 # 0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+# 0.10.0
+* Add ability to toggle anonymous tracking at runtime via `setUserAnonymisation` and `setServerAnonymisation` (BCPF-2051)
+* Migrate web JS interop to `dart:js_interop` and `package:web`
+* Fix iOS integration tests in CI
+
 # 0.9.0
 * Migrate Android example app build to Gradle 8 / Java 21 (#70)
 * Add [static] global contexts (#71) 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This will add a line with the dependency like this to your `pubspec.yaml`:
 
 ```yml
 dependencies:
-    snowplow_tracker: ^0.9.0
+    snowplow_tracker: ^0.10.0
 ```
 
 Import the package into your Dart code:

--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/SnowplowTrackerController.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/SnowplowTrackerController.kt
@@ -118,6 +118,18 @@ object SnowplowTrackerController {
         trackerController?.globalContexts?.remove(messageReader.tag)
     }
 
+    fun setUserAnonymisation(messageReader: SetUserAnonymisationMessageReader) {
+        val trackerController = Snowplow.getTracker(messageReader.tracker)
+
+        trackerController?.userAnonymisation = messageReader.userAnonymisation
+    }
+
+    fun setServerAnonymisation(messageReader: SetServerAnonymisationMessageReader) {
+        val trackerController = Snowplow.getTracker(messageReader.tracker)
+
+        trackerController?.emitter?.serverAnonymisation = messageReader.serverAnonymisation
+    }
+
     fun getSessionUserId(messageReader: GetParameterMessageReader): String? {
         val trackerController = Snowplow.getTracker(messageReader.tracker)
 

--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/SnowplowTrackerPlugin.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/SnowplowTrackerPlugin.kt
@@ -50,6 +50,8 @@ class SnowplowTrackerPlugin: FlutterPlugin, MethodCallHandler {
             "setUserId" -> onSetUserId(call, result)
             "addGlobalContexts" -> onAddGlobalContexts(call, result)
             "removeGlobalContexts" -> onRemoveGlobalContexts(call, result)
+            "setUserAnonymisation" -> onSetUserAnonymisation(call, result)
+            "setServerAnonymisation" -> onSetServerAnonymisation(call, result)
             "getSessionUserId" -> onGetSessionUserId(call, result)
             "getSessionId" -> onGetSessionId(call, result)
             "getSessionIndex" -> onGetSessionIndex(call, result)
@@ -177,6 +179,20 @@ class SnowplowTrackerPlugin: FlutterPlugin, MethodCallHandler {
     private fun onRemoveGlobalContexts(call: MethodCall, result: MethodChannel.Result) {
         (call.arguments as? Map<String, Any>)?.let {
             SnowplowTrackerController.removeGlobalContexts(RemoveGlobalContextsMessageReader(it))
+        }
+        result.success(null)
+    }
+
+    private fun onSetUserAnonymisation(call: MethodCall, result: MethodChannel.Result) {
+        (call.arguments as? Map<String, Any>)?.let {
+            SnowplowTrackerController.setUserAnonymisation(SetUserAnonymisationMessageReader(it))
+        }
+        result.success(null)
+    }
+
+    private fun onSetServerAnonymisation(call: MethodCall, result: MethodChannel.Result) {
+        (call.arguments as? Map<String, Any>)?.let {
+            SnowplowTrackerController.setServerAnonymisation(SetServerAnonymisationMessageReader(it))
         }
         result.success(null)
     }

--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/TrackerVersion.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/TrackerVersion.kt
@@ -12,5 +12,5 @@
 package com.snowplowanalytics.snowplow_tracker
 
 object TrackerVersion {
-    val TRACKER_VERSION = "flutter-0.9.0"
+    val TRACKER_VERSION = "flutter-0.10.0"
 }

--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/messages/SetServerAnonymisationMessageReader.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/messages/SetServerAnonymisationMessageReader.kt
@@ -1,0 +1,17 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+package com.snowplowanalytics.snowplow_tracker.readers.messages
+
+class SetServerAnonymisationMessageReader(val values: Map<String, Any>) {
+    val tracker: String by values
+    val serverAnonymisation: Boolean by values
+}

--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/messages/SetUserAnonymisationMessageReader.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/messages/SetUserAnonymisationMessageReader.kt
@@ -1,0 +1,17 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+package com.snowplowanalytics.snowplow_tracker.readers.messages
+
+class SetUserAnonymisationMessageReader(val values: Map<String, Any>) {
+    val tracker: String by values
+    val userAnonymisation: Boolean by values
+}

--- a/example/integration_test/configuration_test.dart
+++ b/example/integration_test/configuration_test.dart
@@ -190,6 +190,77 @@ void main() {
         isTrue);
   });
 
+  testWidgets("toggles userAnonymisation at runtime without recreating tracker",
+      (WidgetTester tester) async {
+    SnowplowTracker tracker = await Snowplow.createTracker(
+        namespace: 'runtime-user-anonymisation',
+        endpoint: SnowplowTests.microEndpoint,
+        trackerConfig: const TrackerConfiguration(
+            userAnonymisation: false,
+            sessionContext: true,
+            platformContext: true));
+
+    dynamic clientSessionOf(dynamic event) => event['event']['contexts']['data']
+        .firstWhere((x) => x['schema'].toString().contains('client_session'));
+
+    // First event with anonymisation off: userId is a real (non-null) UUID.
+    await tracker
+        .track(const Structured(category: 'category', action: 'action'));
+
+    String? userIdBefore;
+    expect(
+        await SnowplowTests.checkMicroGood((dynamic events) {
+          if (events.length != 1) {
+            return false;
+          }
+          userIdBefore = clientSessionOf(events[0])['data']['userId'];
+          expect(userIdBefore,
+              isNot(equals('00000000-0000-0000-0000-000000000000')));
+          return true;
+        }),
+        isTrue);
+
+    // Toggle anonymisation on at runtime on the same tracker instance.
+    await tracker.setUserAnonymisation(true);
+
+    await SnowplowTests.resetMicro();
+    await tracker
+        .track(const Structured(category: 'category', action: 'action'));
+
+    expect(
+        await SnowplowTests.checkMicroGood((dynamic events) {
+          if (events.length != 1) {
+            return false;
+          }
+          // After the toggle the userId is anonymised to the null UUID,
+          // confirming the runtime change took effect on the live tracker.
+          expect(clientSessionOf(events[0])['data']['userId'],
+              equals('00000000-0000-0000-0000-000000000000'));
+          return true;
+        }),
+        isTrue);
+  });
+
+  testWidgets("toggles serverAnonymisation at runtime",
+      (WidgetTester tester) async {
+    SnowplowTracker tracker = await Snowplow.createTracker(
+        namespace: 'runtime-server-anonymisation',
+        endpoint: SnowplowTests.microEndpoint,
+        emitterConfig: const EmitterConfiguration(serverAnonymisation: false));
+
+    await tracker.setServerAnonymisation(true);
+
+    await tracker
+        .track(const Structured(category: 'category', action: 'action'));
+
+    expect(
+        await SnowplowTests.checkMicroGood((events) =>
+            (events.length == 1) &&
+            (events[0]['event']['network_userid'] ==
+                '00000000-0000-0000-0000-000000000000')),
+        isTrue);
+  });
+
   testWidgets("screenContext and applicationContext on by default",
       (WidgetTester tester) async {
     // screenContext/applicationContext are not available on web

--- a/example/integration_test/configuration_test.dart
+++ b/example/integration_test/configuration_test.dart
@@ -192,6 +192,11 @@ void main() {
 
   testWidgets("toggles userAnonymisation at runtime without recreating tracker",
       (WidgetTester tester) async {
+    // setUserAnonymisation is not supported on Web (throws Unimplemented).
+    if (kIsWeb) {
+      return;
+    }
+
     SnowplowTracker tracker = await Snowplow.createTracker(
         namespace: 'runtime-user-anonymisation',
         endpoint: SnowplowTests.microEndpoint,
@@ -243,6 +248,11 @@ void main() {
 
   testWidgets("toggles serverAnonymisation at runtime",
       (WidgetTester tester) async {
+    // setServerAnonymisation is not supported on Web (throws Unimplemented).
+    if (kIsWeb) {
+      return;
+    }
+
     SnowplowTracker tracker = await Snowplow.createTracker(
         namespace: 'runtime-server-anonymisation',
         endpoint: SnowplowTests.microEndpoint,

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Flutter (1.0.0)
   - integration_test (0.0.1):
     - Flutter
-  - snowplow_tracker (0.9.0):
+  - snowplow_tracker (0.10.0):
     - Flutter
     - SnowplowTracker (~> 6.2.2)
   - SnowplowTracker (6.2.3)

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -2,15 +2,12 @@ import Flutter
 import UIKit
 
 @main
-@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+@objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
-
-  func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
-    GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
   }
 }

--- a/example/lib/overview.dart
+++ b/example/lib/overview.dart
@@ -27,7 +27,7 @@ This will add a line with the dependency like this to your `pubspec.yaml`:
 
 ```yml
 dependencies:
-    snowplow_tracker: ^0.9.0
+    snowplow_tracker: ^0.10.0
 ```
 
 Import the package into your Dart code:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -258,7 +258,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.9.0"
+    version: "0.10.0"
   source_span:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -134,10 +134,10 @@ packages:
     dependency: "direct dev"
     description:
       name: http
-      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.6.0"
   http_parser:
     dependency: transitive
     description:
@@ -151,14 +151,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -359,10 +351,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "4188706108906f002b3a293509234588823c8c979dc83304e229ff400c996b05"
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "1.1.1"
   webdriver:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the snowplow_tracker plugin.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
   flutter: ">=3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
@@ -41,7 +41,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  http: 1.2.0
+  http: ^1.6.0
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.0.0"
+  flutter: ">=3.19.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/ios/Classes/SnowplowTrackerController.swift
+++ b/ios/Classes/SnowplowTrackerController.swift
@@ -132,6 +132,16 @@ class SnowplowTrackerController {
         }
     }
 
+    static func setUserAnonymisation(_ message: SetUserAnonymisationMessageReader) {
+        let trackerController = Snowplow.tracker(namespace: message.tracker)
+        trackerController?.userAnonymisation = message.userAnonymisation
+    }
+
+    static func setServerAnonymisation(_ message: SetServerAnonymisationMessageReader) {
+        let trackerController = Snowplow.tracker(namespace: message.tracker)
+        trackerController?.emitter?.serverAnonymisation = message.serverAnonymisation
+    }
+
     static func startMediaTracking(_ message: StartMediaTrackingMessageReader, arguments: [String: Any]) {
         let configurationArguments = arguments["configuration"] as? [String: Any] ?? [:]
         let mediaTrackingConfiguration = message.configuration.toMediaTrackingConfiguration(arguments: configurationArguments)

--- a/ios/Classes/SwiftSnowplowTrackerPlugin.swift
+++ b/ios/Classes/SwiftSnowplowTrackerPlugin.swift
@@ -51,6 +51,10 @@ public class SwiftSnowplowTrackerPlugin: NSObject, FlutterPlugin {
             onAddGlobalContexts(call, result: result)
         case "removeGlobalContexts":
             onRemoveGlobalContexts(call, result: result)
+        case "setUserAnonymisation":
+            onSetUserAnonymisation(call, result: result)
+        case "setServerAnonymisation":
+            onSetServerAnonymisation(call, result: result)
         case "startMediaTracking":
             onStartMediaTracking(call, result: result)
         case "endMediaTracking":
@@ -228,6 +232,20 @@ public class SwiftSnowplowTrackerPlugin: NSObject, FlutterPlugin {
     private func onRemoveGlobalContexts(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         if let (message, _): (RemoveGlobalContextsMessageReader, Any) = decodeCall(call) {
             SnowplowTrackerController.removeGlobalContexts(message)
+        }
+        result(nil)
+    }
+
+    private func onSetUserAnonymisation(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        if let (message, _): (SetUserAnonymisationMessageReader, Any) = decodeCall(call) {
+            SnowplowTrackerController.setUserAnonymisation(message)
+        }
+        result(nil)
+    }
+
+    private func onSetServerAnonymisation(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        if let (message, _): (SetServerAnonymisationMessageReader, Any) = decodeCall(call) {
+            SnowplowTrackerController.setServerAnonymisation(message)
         }
         result(nil)
     }

--- a/ios/Classes/TrackerVersion.swift
+++ b/ios/Classes/TrackerVersion.swift
@@ -12,5 +12,5 @@
 import Foundation
 
 class TrackerVersion {
-    static let TRACKER_VERSION = "flutter-0.9.0"
+    static let TRACKER_VERSION = "flutter-0.10.0"
 }

--- a/ios/Classes/readers/messages/SetServerAnonymisationMessageReader.swift
+++ b/ios/Classes/readers/messages/SetServerAnonymisationMessageReader.swift
@@ -1,0 +1,17 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import Foundation
+
+struct SetServerAnonymisationMessageReader: Decodable {
+    let tracker: String
+    let serverAnonymisation: Bool
+}

--- a/ios/Classes/readers/messages/SetUserAnonymisationMessageReader.swift
+++ b/ios/Classes/readers/messages/SetUserAnonymisationMessageReader.swift
@@ -1,0 +1,17 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import Foundation
+
+struct SetUserAnonymisationMessageReader: Decodable {
+    let tracker: String
+    let userAnonymisation: Bool
+}

--- a/ios/snowplow_tracker.podspec
+++ b/ios/snowplow_tracker.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'snowplow_tracker'
-  s.version          = '0.9.0'
+  s.version          = '0.10.0'
   s.summary          = 'A package for tracking Snowplow events in Flutter apps.'
   s.description      = <<-DESC
 A package for tracking Snowplow events in Flutter apps.

--- a/lib/snowplow.dart
+++ b/lib/snowplow.dart
@@ -88,8 +88,7 @@ class Snowplow {
   }
 
   /// Adds a global context with the given [tag] to be attached to all tracked events for the [tracker] namespace.
-  static Future<void> addGlobalContexts(
-      String tag, SelfDescribing context,
+  static Future<void> addGlobalContexts(String tag, SelfDescribing context,
       {required String tracker}) async {
     await _channel.invokeMethod('addGlobalContexts', {
       'tracker': tracker,
@@ -103,6 +102,27 @@ class Snowplow {
       {required String tracker}) async {
     await _channel
         .invokeMethod('removeGlobalContexts', {'tracker': tracker, 'tag': tag});
+  }
+
+  /// Sets whether client-side user anonymisation is enabled for the [tracker] namespace.
+  ///
+  /// This toggles the `userAnonymisation` flag at runtime, without having to
+  /// recreate the tracker. Changing it starts a new session but preserves the
+  /// tracker instance. Not supported on Web.
+  static Future<void> setUserAnonymisation(bool userAnonymisation,
+      {required String tracker}) async {
+    await _channel.invokeMethod('setUserAnonymisation',
+        {'tracker': tracker, 'userAnonymisation': userAnonymisation});
+  }
+
+  /// Sets whether server-side anonymisation is enabled for the [tracker] namespace.
+  ///
+  /// This toggles the `serverAnonymisation` flag at runtime (the `SP-Anonymous`
+  /// header), without having to recreate the tracker. Not supported on Web.
+  static Future<void> setServerAnonymisation(bool serverAnonymisation,
+      {required String tracker}) async {
+    await _channel.invokeMethod('setServerAnonymisation',
+        {'tracker': tracker, 'serverAnonymisation': serverAnonymisation});
   }
 
   /// Returns the identifier (string UUIDv4) for the user of the session.

--- a/lib/src/web/snowplow_tracker_controller.dart
+++ b/lib/src/web/snowplow_tracker_controller.dart
@@ -9,8 +9,8 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 
-import 'dart:js_util';
-import 'dart:html';
+import 'dart:js_interop';
+import 'package:web/web.dart' show document;
 
 import 'readers/messages/end_media_tracking_message_reader.dart';
 import 'readers/messages/start_media_tracking_message_reader.dart';
@@ -24,8 +24,8 @@ import 'sp.dart';
 class SnowplowTrackerController {
   static void createTracker(ConfigurationReader configuration) {
     dynamic options = configuration.getTrackerOptions();
-    snowplow('newTracker', configuration.namespace,
-        configuration.networkConfig.endpoint, jsify(options));
+    snowplow('newTracker', configuration.namespace.toJS,
+        configuration.networkConfig.endpoint.toJS, options.jsify());
 
     if (configuration.subjectConfig != null &&
         configuration.subjectConfig?.userId != null) {
@@ -42,21 +42,21 @@ class SnowplowTrackerController {
           configuration.trackerConfig!.webActivityTracking!;
       snowplow(
           'enableActivityTracking',
-          jsify({
+          {
             'minimumVisitLength': webActivityTracking.minimumVisitLength,
             'heartbeatDelay': webActivityTracking.heartbeatDelay
-          }));
+          }.jsify());
     }
 
     if (configuration.trackerConfig?.jsMediaPluginURL != null) {
-      snowplow('addPlugin', configuration.trackerConfig?.jsMediaPluginURL,
-          jsify(['snowplowMedia', 'SnowplowMediaPlugin']));
+      snowplow('addPlugin', configuration.trackerConfig?.jsMediaPluginURL?.toJS,
+          ['snowplowMedia', 'SnowplowMediaPlugin'].jsify());
     }
   }
 
   static void trackEvent(EventMessageReader message) {
     snowplow('${message.event.endpoint()}:${message.tracker}',
-        jsify(message.eventData()));
+        message.eventData().jsify());
   }
 
   static void setUserId(SetUserIdMessageReader message) {
@@ -64,7 +64,7 @@ class SnowplowTrackerController {
   }
 
   static void _setUserId(String tracker, String? userId) {
-    snowplow('setUserId:$tracker', userId);
+    snowplow('setUserId:$tracker', userId?.toJS);
   }
 
   static String? getSessionUserId() {
@@ -85,34 +85,31 @@ class SnowplowTrackerController {
 
   static void startMediaTracking(StartMediaTrackingMessageReader message) {
     snowplow('startMediaTracking:${message.tracker}',
-        jsify(message.configuration.toTrackerOptions()));
+        message.configuration.toTrackerOptions().jsify());
   }
 
   static void endMediaTracking(EndMediaTrackingMessageReader message) {
     snowplow('endMediaTracking:${message.tracker}',
-        jsify({'id': message.mediaTrackingId}));
+        {'id': message.mediaTrackingId}.jsify());
   }
 
   static void updateMediaTracking(UpdateMediaTrackingMessageReader message) {
-    snowplow('updateMediaTracking:${message.tracker}', jsify(message.toMap()));
+    snowplow('updateMediaTracking:${message.tracker}', message.toMap().jsify());
   }
 
   static List<String>? _getSnowplowCookieParts() {
     final regex = RegExp(r'_sp_id\.[a-f0-9]+=([^;]+);?');
-    if (document.cookie != null) {
-      final cookieValue = regex.firstMatch(document.cookie!)?.group(1);
-      return cookieValue?.split('.');
-    }
-    return null;
+    final cookieValue = regex.firstMatch(document.cookie)?.group(1);
+    return cookieValue?.split('.');
   }
 
   static void addGlobalContexts(String tracker, String tag, dynamic context) {
     if (context != null) {
-      snowplow('addGlobalContexts', jsify({tag: context}));
+      snowplow('addGlobalContexts', {tag: context}.jsify());
     }
   }
 
   static void removeGlobalContexts(String tracker, String tag) {
-    snowplow('removeGlobalContexts', jsify([tag]));
+    snowplow('removeGlobalContexts', [tag].jsify());
   }
 }

--- a/lib/src/web/sp.dart
+++ b/lib/src/web/sp.dart
@@ -9,16 +9,13 @@
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
 
-@JS()
-library snowplow;
-
-import 'package:js/js.dart';
+import 'dart:js_interop';
 
 @JS('window.snowplow')
 external void snowplow(String method,
-    [dynamic arg1,
-    dynamic arg2,
-    dynamic arg3,
-    dynamic arg4,
-    dynamic arg5,
-    dynamic arg6]);
+    [JSAny? arg1,
+    JSAny? arg2,
+    JSAny? arg3,
+    JSAny? arg4,
+    JSAny? arg5,
+    JSAny? arg6]);

--- a/lib/tracker.dart
+++ b/lib/tracker.dart
@@ -41,14 +41,32 @@ class SnowplowTracker {
   }
 
   /// Adds a global context with the given [tag] to be attached to all tracked events.
-  Future<void> addGlobalContexts(
-      String tag, SelfDescribing context) async {
+  Future<void> addGlobalContexts(String tag, SelfDescribing context) async {
     await Snowplow.addGlobalContexts(tag, context, tracker: namespace);
   }
 
   /// Removes global contexts with the given [tag].
   Future<void> removeGlobalContexts(String tag) async {
     await Snowplow.removeGlobalContexts(tag, tracker: namespace);
+  }
+
+  /// Sets whether client-side user anonymisation is enabled.
+  ///
+  /// This toggles the `userAnonymisation` flag at runtime, without having to
+  /// recreate the tracker. Changing it starts a new session but preserves the
+  /// tracker instance. Not supported on Web.
+  Future<void> setUserAnonymisation(bool userAnonymisation) async {
+    await Snowplow.setUserAnonymisation(userAnonymisation, tracker: namespace);
+  }
+
+  /// Sets whether server-side anonymisation is enabled (the `SP-Anonymous`
+  /// header).
+  ///
+  /// This toggles the `serverAnonymisation` flag at runtime, without having to
+  /// recreate the tracker. Not supported on Web.
+  Future<void> setServerAnonymisation(bool serverAnonymisation) async {
+    await Snowplow.setServerAnonymisation(serverAnonymisation,
+        tracker: namespace);
   }
 
   /// Returns the identifier (string UUIDv4) for the user of the session.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/snowplow/snowplow-flutter-tracker
 repository: https://github.com/snowplow/snowplow-flutter-tracker
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ">=3.3.0 <4.0.0"
   flutter: ">=3.0.0"
 
 dependencies:
@@ -13,14 +13,14 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  js: ^0.7.1
+  web: ^1.0.0
   uuid: ^4.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^4.0.0
-  http: "1.2.0"
+  http: "^1.6.0"
 
 flutter:
   plugin:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: snowplow_tracker
 description: A package for tracking Snowplow events in Flutter apps
-version: 0.9.0
+version: 0.10.0
 homepage: https://github.com/snowplow/snowplow-flutter-tracker
 repository: https://github.com/snowplow/snowplow-flutter-tracker
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/snowplow/snowplow-flutter-tracker
 
 environment:
   sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.0.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:

--- a/test/snowplow_test.dart
+++ b/test/snowplow_test.dart
@@ -462,4 +462,22 @@ void main() {
         isMethodCall('removeGlobalContexts',
             arguments: {'tracker': 'tns1', 'tag': 'ctx_tag_1'}));
   });
+
+  test('sets user anonymisation', () async {
+    await Snowplow.setUserAnonymisation(true, tracker: 'tns1');
+
+    expect(
+        methodCall,
+        isMethodCall('setUserAnonymisation',
+            arguments: {'tracker': 'tns1', 'userAnonymisation': true}));
+  });
+
+  test('sets server anonymisation', () async {
+    await Snowplow.setServerAnonymisation(false, tracker: 'tns1');
+
+    expect(
+        methodCall,
+        isMethodCall('setServerAnonymisation',
+            arguments: {'tracker': 'tns1', 'serverAnonymisation': false}));
+  });
 }

--- a/test/tracker_test.dart
+++ b/test/tracker_test.dart
@@ -69,4 +69,20 @@ void main() {
     expect(arguments['tracker'], equals('ns1'));
     expect(sessionId, equals('1234'));
   });
+
+  test('sets user anonymisation', () async {
+    await tracker?.setUserAnonymisation(true);
+
+    expect(method, equals('setUserAnonymisation'));
+    expect(arguments['tracker'], equals('ns1'));
+    expect(arguments['userAnonymisation'], equals(true));
+  });
+
+  test('sets server anonymisation', () async {
+    await tracker?.setServerAnonymisation(true);
+
+    expect(method, equals('setServerAnonymisation'));
+    expect(arguments['tracker'], equals('ns1'));
+    expect(arguments['serverAnonymisation'], equals(true));
+  });
 }


### PR DESCRIPTION
This release adds the ability to toggle anonymous tracking at runtime on the mobile trackers, migrates the web tracker to the modern `dart:js_interop`, and repairs the iOS CI pipeline.

**Enhancements**
- Add `setUserAnonymisation` and `setServerAnonymisation` to change the anonymisation level on a live tracker without recreating it (BCPF-2051). Mobile only; on Web these throw the existing Unimplemented `PlatformException`.

**Fixes**
- Migrate web JS interop from the removed `package:js` / `dart:js_util` / `dart:html` to `dart:js_interop` and `package:web`, fixing `flutter analyze`.

**Under the hood**
- Repair the iOS integration CI job (retired `macos-12` runner, example `AppDelegate` regenerated by a newer SDK, and the simulator-attach hang under the pinned Flutter — now pinned to 3.35.4 and run via `flutter test`). Add a 30-minute job timeout and stop the workflow running twice on PR pushes.

> **Note for reviewers:** toggling `userAnonymisation` starts a new session natively — the tracker instance and user id are preserved, but the `sessionId` rolls over. The remaining behaviour is verified by new unit and integration tests; CI is green except where noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)