### PR TITLE
feat(flutter-tracker): add deep link and push notification event tracking

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,7 @@ android {
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
+        test.java.srcDirs += 'src/test/kotlin'
     }
 
     defaultConfig {
@@ -52,4 +53,6 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "com.snowplowanalytics:snowplow-android-tracker:6.2.+"
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
 }

--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/SnowplowTrackerController.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/SnowplowTrackerController.kt
@@ -305,6 +305,16 @@ object SnowplowTrackerController {
         trackEvent(pageView, eventReader)
     }
 
+    fun trackDeepLinkReceived(eventReader: EventMessageReader) {
+        val event = eventReader.toDeepLinkReceivedWithContexts()
+        trackEvent(event, eventReader)
+    }
+
+    fun trackMessageNotification(eventReader: EventMessageReader) {
+        val event = eventReader.toMessageNotificationWithContexts()
+        trackEvent(event, eventReader)
+    }
+
     private fun trackEvent(event: Event, messageReader: EventMessageReader) {
         val trackerController = Snowplow.getTracker(messageReader.tracker)
         val mediaTrackingId = messageReader.mediaTrackingId

--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/SnowplowTrackerPlugin.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/SnowplowTrackerPlugin.kt
@@ -88,6 +88,8 @@ class SnowplowTrackerPlugin: FlutterPlugin, MethodCallHandler {
             "trackMediaVolumeChangeEvent" -> onTrackMediaVolumeChangeEvent(call, result)
             "trackWebViewReader" -> onTrackWebViewReaderEvent(call, result)
             "trackPageView" -> onTrackPageView(call, result)
+            "trackDeepLinkReceived" -> onTrackDeepLinkReceived(call, result)
+            "trackMessageNotification" -> onTrackMessageNotification(call, result)
             else -> result.notImplemented()
         }
     }
@@ -430,6 +432,20 @@ class SnowplowTrackerPlugin: FlutterPlugin, MethodCallHandler {
     private fun onTrackPageView(call: MethodCall, result: MethodChannel.Result) {
         (call.arguments as? Map<String, Any>)?.let {
             SnowplowTrackerController.trackPageView(EventMessageReader(it))
+        }
+        result.success(null)
+    }
+
+    private fun onTrackDeepLinkReceived(call: MethodCall, result: MethodChannel.Result) {
+        (call.arguments as? Map<String, Any>)?.let {
+            SnowplowTrackerController.trackDeepLinkReceived(EventMessageReader(it))
+        }
+        result.success(null)
+    }
+
+    private fun onTrackMessageNotification(call: MethodCall, result: MethodChannel.Result) {
+        (call.arguments as? Map<String, Any>)?.let {
+            SnowplowTrackerController.trackMessageNotification(EventMessageReader(it))
         }
         result.success(null)
     }

--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/events/DeepLinkReceivedReader.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/events/DeepLinkReceivedReader.kt
@@ -1,0 +1,27 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+package com.snowplowanalytics.snowplow_tracker.readers.events
+
+import com.snowplowanalytics.snowplow.event.DeepLinkReceived
+
+class DeepLinkReceivedReader(val values: Map<String, Any>) {
+    private val valuesDefault = values.withDefault { null }
+
+    val url: String by values
+    val referrer: String? by valuesDefault
+
+    fun toDeepLinkReceived(): DeepLinkReceived {
+        val event = DeepLinkReceived(url)
+        referrer?.let { event.referrer(it) }
+        return event
+    }
+}

--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/events/MessageNotificationReader.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/events/MessageNotificationReader.kt
@@ -1,0 +1,66 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+package com.snowplowanalytics.snowplow_tracker.readers.events
+
+import com.snowplowanalytics.snowplow.event.MessageNotification
+import com.snowplowanalytics.snowplow.event.MessageNotificationAttachment
+import com.snowplowanalytics.snowplow.event.MessageNotificationTrigger
+
+class MessageNotificationReader(val values: Map<String, Any>) {
+    private val valuesDefault = values.withDefault { null }
+
+    val title: String by values
+    val body: String by values
+    private val trigger: String by values
+    val action: String? by valuesDefault
+    val badge: Int? by lazy { (values["badge"] as? Number)?.toInt() }
+    val categoryIdentifier: String? by valuesDefault
+    val launchImageName: String? by valuesDefault
+    val notificationTimestamp: String? by valuesDefault
+    val sound: String? by valuesDefault
+    val subtitle: String? by valuesDefault
+    val threadIdentifier: String? by valuesDefault
+    private val attachmentsRaw: List<Map<String, Any>>? by valuesDefault
+    private val processedAttachments: List<MessageNotificationAttachment>? by lazy {
+        attachmentsRaw?.map { map ->
+            MessageNotificationAttachment(
+                map["identifier"] as String,
+                map["type"] as String,
+                map["url"] as String
+            )
+        }
+    }
+
+    private fun toTrigger(): MessageNotificationTrigger {
+        return when (trigger) {
+            "push" -> MessageNotificationTrigger.push
+            "calendar" -> MessageNotificationTrigger.calendar
+            "timeInterval" -> MessageNotificationTrigger.timeInterval
+            "location" -> MessageNotificationTrigger.location
+            else -> MessageNotificationTrigger.push
+        }
+    }
+
+    fun toMessageNotification(): MessageNotification {
+        val event = MessageNotification(title, body, toTrigger())
+        action?.let { event.action(it) }
+        badge?.let { event.badge(it) }
+        categoryIdentifier?.let { event.categoryIdentifier(it) }
+        launchImageName?.let { event.launchImageName(it) }
+        notificationTimestamp?.let { event.notificationTimestamp(it) }
+        sound?.let { event.sound(it) }
+        subtitle?.let { event.subtitle(it) }
+        threadIdentifier?.let { event.thread(it) }
+        processedAttachments?.let { event.attachments(it) }
+        return event
+    }
+}

--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/events/MessageNotificationReader.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/events/MessageNotificationReader.kt
@@ -22,13 +22,22 @@ class MessageNotificationReader(val values: Map<String, Any>) {
     val body: String by values
     private val trigger: String by values
     val action: String? by valuesDefault
-    val badge: Int? by lazy { (values["badge"] as? Number)?.toInt() }
-    val categoryIdentifier: String? by valuesDefault
-    val launchImageName: String? by valuesDefault
+    @Suppress("UNCHECKED_CAST")
+    val bodyLocArgs: List<String>? by lazy { values["bodyLocArgs"] as? List<String> }
+    val bodyLocKey: String? by valuesDefault
+    val category: String? by valuesDefault
+    val contentAvailable: Boolean? by valuesDefault
+    val group: String? by valuesDefault
+    val icon: String? by valuesDefault
+    val notificationCount: Int? by lazy { (values["notificationCount"] as? Number)?.toInt() }
     val notificationTimestamp: String? by valuesDefault
     val sound: String? by valuesDefault
     val subtitle: String? by valuesDefault
+    val tag: String? by valuesDefault
     val threadIdentifier: String? by valuesDefault
+    @Suppress("UNCHECKED_CAST")
+    val titleLocArgs: List<String>? by lazy { values["titleLocArgs"] as? List<String> }
+    val titleLocKey: String? by valuesDefault
     private val attachmentsRaw: List<Map<String, Any>>? by valuesDefault
     private val processedAttachments: List<MessageNotificationAttachment>? by lazy {
         attachmentsRaw?.map { map ->
@@ -53,14 +62,21 @@ class MessageNotificationReader(val values: Map<String, Any>) {
     fun toMessageNotification(): MessageNotification {
         val event = MessageNotification(title, body, toTrigger())
         action?.let { event.action(it) }
-        badge?.let { event.badge(it) }
-        categoryIdentifier?.let { event.categoryIdentifier(it) }
-        launchImageName?.let { event.launchImageName(it) }
+        processedAttachments?.let { event.attachments(it) }
+        bodyLocArgs?.let { event.bodyLocArgs(it) }
+        bodyLocKey?.let { event.bodyLocKey(it) }
+        category?.let { event.category(it) }
+        contentAvailable?.let { event.contentAvailable(it) }
+        group?.let { event.group(it) }
+        icon?.let { event.icon(it) }
+        notificationCount?.let { event.notificationCount(it) }
         notificationTimestamp?.let { event.notificationTimestamp(it) }
         sound?.let { event.sound(it) }
         subtitle?.let { event.subtitle(it) }
-        threadIdentifier?.let { event.thread(it) }
-        processedAttachments?.let { event.attachments(it) }
+        tag?.let { event.tag(it) }
+        threadIdentifier?.let { event.threadIdentifier(it) }
+        titleLocArgs?.let { event.titleLocArgs(it) }
+        titleLocKey?.let { event.titleLocKey(it) }
         return event
     }
 }

--- a/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/messages/EventMessageReader.kt
+++ b/android/src/main/kotlin/com/snowplowanalytics/snowplow_tracker/readers/messages/EventMessageReader.kt
@@ -256,6 +256,18 @@ class EventMessageReader(val values: Map<String, Any>) {
         return pageView
     }
 
+    fun toDeepLinkReceivedWithContexts(): DeepLinkReceived {
+        val event = DeepLinkReceivedReader(eventData).toDeepLinkReceived()
+        addContext(event)
+        return event
+    }
+
+    fun toMessageNotificationWithContexts(): MessageNotification {
+        val event = MessageNotificationReader(eventData).toMessageNotification()
+        addContext(event)
+        return event
+    }
+
     private fun addContext(event: Event) {
         contextsJsons?.let { event.entities.addAll(it) }
     }

--- a/android/src/test/kotlin/com/snowplowanalytics/snowplow_tracker/readers/events/DeepLinkReceivedReaderTest.kt
+++ b/android/src/test/kotlin/com/snowplowanalytics/snowplow_tracker/readers/events/DeepLinkReceivedReaderTest.kt
@@ -1,0 +1,60 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+package com.snowplowanalytics.snowplow_tracker.readers.events
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class DeepLinkReceivedReaderTest {
+
+    @Test
+    fun `reader extracts required url`() {
+        val map = mapOf("url" to "https://example.com/path")
+        val reader = DeepLinkReceivedReader(map)
+
+        assertEquals("https://example.com/path", reader.url)
+        assertNull(reader.referrer)
+    }
+
+    @Test
+    fun `reader extracts optional referrer`() {
+        val map = mapOf(
+            "url" to "https://example.com/path",
+            "referrer" to "https://referrer.example.com"
+        )
+        val reader = DeepLinkReceivedReader(map)
+
+        assertEquals("https://example.com/path", reader.url)
+        assertEquals("https://referrer.example.com", reader.referrer)
+    }
+
+    @Test
+    fun `toDeepLinkReceived produces event with url`() {
+        val map = mapOf("url" to "https://example.com/path")
+        val reader = DeepLinkReceivedReader(map)
+        val event = reader.toDeepLinkReceived()
+
+        assertNotNull(event)
+    }
+
+    @Test
+    fun `toDeepLinkReceived produces event with referrer`() {
+        val map = mapOf(
+            "url" to "https://example.com/path",
+            "referrer" to "https://referrer.example.com"
+        )
+        val reader = DeepLinkReceivedReader(map)
+        val event = reader.toDeepLinkReceived()
+
+        assertNotNull(event)
+    }
+}

--- a/android/src/test/kotlin/com/snowplowanalytics/snowplow_tracker/readers/events/MessageNotificationReaderTest.kt
+++ b/android/src/test/kotlin/com/snowplowanalytics/snowplow_tracker/readers/events/MessageNotificationReaderTest.kt
@@ -36,24 +36,38 @@ class MessageNotificationReaderTest {
             "body" to "Body",
             "trigger" to "calendar",
             "action" to "Open",
-            "badge" to 3,
-            "categoryIdentifier" to "cat1",
-            "launchImageName" to "launch",
+            "bodyLocArgs" to listOf("bodyArg"),
+            "bodyLocKey" to "bodyKey",
+            "category" to "cat1",
+            "contentAvailable" to true,
+            "group" to "group1",
+            "icon" to "icon1",
+            "notificationCount" to 5,
             "notificationTimestamp" to "2023-01-01T00:00:00Z",
             "sound" to "default",
             "subtitle" to "Subtitle",
-            "threadIdentifier" to "thread1"
+            "tag" to "tag1",
+            "threadIdentifier" to "thread1",
+            "titleLocArgs" to listOf("titleArg"),
+            "titleLocKey" to "titleKey"
         )
         val reader = MessageNotificationReader(map)
 
         assertEquals("Open", reader.action)
-        assertEquals(3, reader.badge)
-        assertEquals("cat1", reader.categoryIdentifier)
-        assertEquals("launch", reader.launchImageName)
+        assertEquals(listOf("bodyArg"), reader.bodyLocArgs)
+        assertEquals("bodyKey", reader.bodyLocKey)
+        assertEquals("cat1", reader.category)
+        assertEquals(true, reader.contentAvailable)
+        assertEquals("group1", reader.group)
+        assertEquals("icon1", reader.icon)
+        assertEquals(5, reader.notificationCount)
         assertEquals("2023-01-01T00:00:00Z", reader.notificationTimestamp)
         assertEquals("default", reader.sound)
         assertEquals("Subtitle", reader.subtitle)
+        assertEquals("tag1", reader.tag)
         assertEquals("thread1", reader.threadIdentifier)
+        assertEquals(listOf("titleArg"), reader.titleLocArgs)
+        assertEquals("titleKey", reader.titleLocKey)
     }
 
     @Test
@@ -66,13 +80,20 @@ class MessageNotificationReaderTest {
         val reader = MessageNotificationReader(map)
 
         assertNull(reader.action)
-        assertNull(reader.badge)
-        assertNull(reader.categoryIdentifier)
-        assertNull(reader.launchImageName)
+        assertNull(reader.bodyLocArgs)
+        assertNull(reader.bodyLocKey)
+        assertNull(reader.category)
+        assertNull(reader.contentAvailable)
+        assertNull(reader.group)
+        assertNull(reader.icon)
+        assertNull(reader.notificationCount)
         assertNull(reader.notificationTimestamp)
         assertNull(reader.sound)
         assertNull(reader.subtitle)
+        assertNull(reader.tag)
         assertNull(reader.threadIdentifier)
+        assertNull(reader.titleLocArgs)
+        assertNull(reader.titleLocKey)
     }
 
     @Test
@@ -100,9 +121,8 @@ class MessageNotificationReaderTest {
             "body" to "Body",
             "trigger" to "timeInterval",
             "action" to "Open",
-            "badge" to 2,
-            "categoryIdentifier" to "cat1",
-            "launchImageName" to "launch",
+            "category" to "cat1",
+            "notificationCount" to 2,
             "notificationTimestamp" to "2023-01-01T00:00:00Z",
             "sound" to "default",
             "subtitle" to "Subtitle",

--- a/android/src/test/kotlin/com/snowplowanalytics/snowplow_tracker/readers/events/MessageNotificationReaderTest.kt
+++ b/android/src/test/kotlin/com/snowplowanalytics/snowplow_tracker/readers/events/MessageNotificationReaderTest.kt
@@ -1,0 +1,131 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+package com.snowplowanalytics.snowplow_tracker.readers.events
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class MessageNotificationReaderTest {
+
+    @Test
+    fun `reader extracts required fields`() {
+        val map = mapOf(
+            "title" to "Test Title",
+            "body" to "Test Body",
+            "trigger" to "push"
+        )
+        val reader = MessageNotificationReader(map)
+
+        assertEquals("Test Title", reader.title)
+        assertEquals("Test Body", reader.body)
+    }
+
+    @Test
+    fun `reader extracts optional fields`() {
+        val map = mapOf(
+            "title" to "Title",
+            "body" to "Body",
+            "trigger" to "calendar",
+            "action" to "Open",
+            "badge" to 3,
+            "categoryIdentifier" to "cat1",
+            "launchImageName" to "launch",
+            "notificationTimestamp" to "2023-01-01T00:00:00Z",
+            "sound" to "default",
+            "subtitle" to "Subtitle",
+            "threadIdentifier" to "thread1"
+        )
+        val reader = MessageNotificationReader(map)
+
+        assertEquals("Open", reader.action)
+        assertEquals(3, reader.badge)
+        assertEquals("cat1", reader.categoryIdentifier)
+        assertEquals("launch", reader.launchImageName)
+        assertEquals("2023-01-01T00:00:00Z", reader.notificationTimestamp)
+        assertEquals("default", reader.sound)
+        assertEquals("Subtitle", reader.subtitle)
+        assertEquals("thread1", reader.threadIdentifier)
+    }
+
+    @Test
+    fun `reader nulls optional fields when absent`() {
+        val map = mapOf(
+            "title" to "Title",
+            "body" to "Body",
+            "trigger" to "push"
+        )
+        val reader = MessageNotificationReader(map)
+
+        assertNull(reader.action)
+        assertNull(reader.badge)
+        assertNull(reader.categoryIdentifier)
+        assertNull(reader.launchImageName)
+        assertNull(reader.notificationTimestamp)
+        assertNull(reader.sound)
+        assertNull(reader.subtitle)
+        assertNull(reader.threadIdentifier)
+    }
+
+    @Test
+    fun `toMessageNotification produces event with required fields`() {
+        val map = mapOf(
+            "title" to "Title",
+            "body" to "Body",
+            "trigger" to "push"
+        )
+        val reader = MessageNotificationReader(map)
+        val event = reader.toMessageNotification()
+
+        assertNotNull(event)
+    }
+
+    @Test
+    fun `toMessageNotification produces event with all optional fields`() {
+        val attachmentMap = mapOf(
+            "identifier" to "att1",
+            "type" to "image/png",
+            "url" to "https://example.com/image.png"
+        )
+        val map = mapOf(
+            "title" to "Title",
+            "body" to "Body",
+            "trigger" to "timeInterval",
+            "action" to "Open",
+            "badge" to 2,
+            "categoryIdentifier" to "cat1",
+            "launchImageName" to "launch",
+            "notificationTimestamp" to "2023-01-01T00:00:00Z",
+            "sound" to "default",
+            "subtitle" to "Subtitle",
+            "threadIdentifier" to "thread1",
+            "attachments" to listOf(attachmentMap)
+        )
+        val reader = MessageNotificationReader(map)
+        val event = reader.toMessageNotification()
+
+        assertNotNull(event)
+    }
+
+    @Test
+    fun `reader handles all trigger values`() {
+        listOf("push", "calendar", "timeInterval", "location").forEach { triggerStr ->
+            val map = mapOf(
+                "title" to "Title",
+                "body" to "Body",
+                "trigger" to triggerStr
+            )
+            val reader = MessageNotificationReader(map)
+            val event = reader.toMessageNotification()
+            assertNotNull("Event should not be null for trigger: $triggerStr", event)
+        }
+    }
+}

--- a/example/integration_test/events_test.dart
+++ b/example/integration_test/events_test.dart
@@ -262,11 +262,19 @@ void main() {
       return;
     }
 
-    // PageView is now supported on mobile — should not throw
+    // PageView is now supported on mobile — should not throw.
+    // Await delivery so the event does not leak into the next test's
+    // Micro state (the emitter flushes asynchronously).
     await Snowplow.track(
       const PageViewEvent(url: 'https://example.com'),
       tracker: 'test',
     );
+
+    expect(
+        await SnowplowTests.checkMicroGood((events) =>
+            (events.length == 1) &&
+            (events[0]['event']['page_url'] == 'https://example.com')),
+        isTrue);
   });
 
   testWidgets("tracks a deep link received event on mobile",
@@ -287,8 +295,8 @@ void main() {
         await SnowplowTests.checkMicroGood((events) =>
             (events.length == 1) &&
             (events[0]['event']['unstruct_event']['data']['schema']
-                    .toString()
-                    .contains('deep_link_received')) &&
+                .toString()
+                .contains('deep_link_received')) &&
             (events[0]['event']['unstruct_event']['data']['data']['url'] ==
                 'https://example.com/deep?id=1')),
         isTrue);
@@ -315,8 +323,8 @@ void main() {
         await SnowplowTests.checkMicroGood((events) =>
             (events.length == 1) &&
             (events[0]['event']['unstruct_event']['data']['schema']
-                    .toString()
-                    .contains('message_notification')) &&
+                .toString()
+                .contains('message_notification')) &&
             (events[0]['event']['unstruct_event']['data']['data']['title'] ==
                 'Test Notification') &&
             (events[0]['event']['unstruct_event']['data']['data']['body'] ==

--- a/example/integration_test/events_test.dart
+++ b/example/integration_test/events_test.dart
@@ -268,4 +268,61 @@ void main() {
       tracker: 'test',
     );
   });
+
+  testWidgets("tracks a deep link received event on mobile",
+      (WidgetTester tester) async {
+    if (kIsWeb) {
+      return;
+    }
+
+    await Snowplow.track(
+      const DeepLinkReceived(
+        url: 'https://example.com/deep?id=1',
+        referrer: 'https://referrer.example.com',
+      ),
+      tracker: 'test',
+    );
+
+    expect(
+        await SnowplowTests.checkMicroGood((events) =>
+            (events.length == 1) &&
+            (events[0]['event']['unstruct_event']['data']['schema']
+                    .toString()
+                    .contains('deep_link_received')) &&
+            (events[0]['event']['unstruct_event']['data']['data']['url'] ==
+                'https://example.com/deep?id=1')),
+        isTrue);
+  });
+
+  testWidgets("tracks a message notification event on mobile",
+      (WidgetTester tester) async {
+    if (kIsWeb) {
+      return;
+    }
+
+    await Snowplow.track(
+      const MessageNotification(
+        title: 'Test Notification',
+        body: 'Notification body',
+        trigger: 'push',
+        action: 'Open',
+        sound: 'default',
+      ),
+      tracker: 'test',
+    );
+
+    expect(
+        await SnowplowTests.checkMicroGood((events) =>
+            (events.length == 1) &&
+            (events[0]['event']['unstruct_event']['data']['schema']
+                    .toString()
+                    .contains('message_notification')) &&
+            (events[0]['event']['unstruct_event']['data']['data']['title'] ==
+                'Test Notification') &&
+            (events[0]['event']['unstruct_event']['data']['data']['body'] ==
+                'Notification body') &&
+            (events[0]['event']['unstruct_event']['data']['data']['trigger'] ==
+                'push')),
+        isTrue);
+  });
 }

--- a/ios/Classes/SnowplowTrackerController.swift
+++ b/ios/Classes/SnowplowTrackerController.swift
@@ -94,6 +94,16 @@ class SnowplowTrackerController {
         trackEvent(event, eventMessage: eventMessage, arguments: arguments)
     }
 
+    static func trackDeepLinkReceived(_ message: TrackDeepLinkReceivedMessageReader, eventMessage: EventMessageReader, arguments: [String: Any]) {
+        let event = message.toDeepLinkReceived()
+        trackEvent(event, eventMessage: eventMessage, arguments: arguments)
+    }
+
+    static func trackMessageNotification(_ message: TrackMessageNotificationMessageReader, eventMessage: EventMessageReader, arguments: [String: Any]) {
+        let event = message.toMessageNotification()
+        trackEvent(event, eventMessage: eventMessage, arguments: arguments)
+    }
+
     static func sessionUserId(_ message: GetParameterMessageReader) -> String? {
         return Snowplow.tracker(namespace: message.tracker)?.session?.userId
     }

--- a/ios/Classes/SwiftSnowplowTrackerPlugin.swift
+++ b/ios/Classes/SwiftSnowplowTrackerPlugin.swift
@@ -115,6 +115,10 @@ public class SwiftSnowplowTrackerPlugin: NSObject, FlutterPlugin {
             onTrackWebViewReader(call, result: result)
         case "trackPageView":
             onTrackPageView(call, result: result)
+        case "trackDeepLinkReceived":
+            onTrackDeepLinkReceived(call, result: result)
+        case "trackMessageNotification":
+            onTrackMessageNotification(call, result: result)
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -468,6 +472,22 @@ public class SwiftSnowplowTrackerPlugin: NSObject, FlutterPlugin {
         if let (message, arguments): (TrackPageViewMessageReader, [String: Any]) = decodeCall(call),
             let (eventMessage, _): (EventMessageReader, Any) = decodeCall(call) {
             SnowplowTrackerController.trackPageView(message, eventMessage: eventMessage, arguments: arguments)
+        }
+        result(nil)
+    }
+
+    private func onTrackDeepLinkReceived(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        if let (message, arguments): (TrackDeepLinkReceivedMessageReader, [String: Any]) = decodeCall(call),
+            let (eventMessage, _): (EventMessageReader, Any) = decodeCall(call) {
+            SnowplowTrackerController.trackDeepLinkReceived(message, eventMessage: eventMessage, arguments: arguments)
+        }
+        result(nil)
+    }
+
+    private func onTrackMessageNotification(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        if let (message, arguments): (TrackMessageNotificationMessageReader, [String: Any]) = decodeCall(call),
+            let (eventMessage, _): (EventMessageReader, Any) = decodeCall(call) {
+            SnowplowTrackerController.trackMessageNotification(message, eventMessage: eventMessage, arguments: arguments)
         }
         result(nil)
     }

--- a/ios/Classes/readers/events/DeepLinkReceivedReader.swift
+++ b/ios/Classes/readers/events/DeepLinkReceivedReader.swift
@@ -1,0 +1,26 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import Foundation
+import SnowplowTracker
+
+struct DeepLinkReceivedReader: Decodable {
+    let url: String
+    let referrer: String?
+}
+
+extension DeepLinkReceivedReader {
+    func toDeepLinkReceived() -> DeepLinkReceived {
+        let event = DeepLinkReceived(url: url)
+        if let r = self.referrer { event.referrer(r) }
+        return event
+    }
+}

--- a/ios/Classes/readers/events/MessageNotificationReader.swift
+++ b/ios/Classes/readers/events/MessageNotificationReader.swift
@@ -1,0 +1,66 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import Foundation
+import SnowplowTracker
+
+struct MessageNotificationAttachmentReader: Decodable {
+    let identifier: String
+    let type: String
+    let url: String
+
+    func toAttachment() -> MessageNotificationAttachment {
+        return MessageNotificationAttachment(identifier: identifier, type: type, url: url)
+    }
+}
+
+struct MessageNotificationReader: Decodable {
+    let title: String
+    let body: String
+    let trigger: String
+    let action: String?
+    let badge: Int?
+    let categoryIdentifier: String?
+    let launchImageName: String?
+    let notificationTimestamp: String?
+    let sound: String?
+    let subtitle: String?
+    let threadIdentifier: String?
+    let attachments: [MessageNotificationAttachmentReader]?
+
+    private func toTrigger() -> MessageNotificationTrigger {
+        switch trigger {
+        case "push": return .push
+        case "calendar": return .calendar
+        case "timeInterval": return .timeInterval
+        case "location": return .location
+        default: return .push
+        }
+    }
+}
+
+extension MessageNotificationReader {
+    func toMessageNotification() -> MessageNotification {
+        let event = MessageNotification(title: title, body: body, trigger: toTrigger())
+        if let a = self.action { event.action(a) }
+        if let b = self.badge { event.badge(b) }
+        if let ci = self.categoryIdentifier { event.categoryIdentifier(ci) }
+        if let li = self.launchImageName { event.launchImageName(li) }
+        if let nt = self.notificationTimestamp { event.notificationTimestamp(nt) }
+        if let s = self.sound { event.sound(s) }
+        if let st = self.subtitle { event.subtitle(st) }
+        if let ti = self.threadIdentifier { event.thread(ti) }
+        if let att = self.attachments {
+            event.attachments(att.map { $0.toAttachment() })
+        }
+        return event
+    }
+}

--- a/ios/Classes/readers/events/MessageNotificationReader.swift
+++ b/ios/Classes/readers/events/MessageNotificationReader.swift
@@ -27,14 +27,21 @@ struct MessageNotificationReader: Decodable {
     let body: String
     let trigger: String
     let action: String?
-    let badge: Int?
-    let categoryIdentifier: String?
-    let launchImageName: String?
+    let attachments: [MessageNotificationAttachmentReader]?
+    let bodyLocArgs: [String]?
+    let bodyLocKey: String?
+    let category: String?
+    let contentAvailable: Bool?
+    let group: String?
+    let icon: String?
+    let notificationCount: Int?
     let notificationTimestamp: String?
     let sound: String?
     let subtitle: String?
+    let tag: String?
     let threadIdentifier: String?
-    let attachments: [MessageNotificationAttachmentReader]?
+    let titleLocArgs: [String]?
+    let titleLocKey: String?
 
     private func toTrigger() -> MessageNotificationTrigger {
         switch trigger {
@@ -50,17 +57,22 @@ struct MessageNotificationReader: Decodable {
 extension MessageNotificationReader {
     func toMessageNotification() -> MessageNotification {
         let event = MessageNotification(title: title, body: body, trigger: toTrigger())
-        if let a = self.action { event.action(a) }
-        if let b = self.badge { event.badge(b) }
-        if let ci = self.categoryIdentifier { event.categoryIdentifier(ci) }
-        if let li = self.launchImageName { event.launchImageName(li) }
-        if let nt = self.notificationTimestamp { event.notificationTimestamp(nt) }
-        if let s = self.sound { event.sound(s) }
-        if let st = self.subtitle { event.subtitle(st) }
-        if let ti = self.threadIdentifier { event.thread(ti) }
-        if let att = self.attachments {
-            event.attachments(att.map { $0.toAttachment() })
-        }
+        event.action = action
+        event.attachments = attachments?.map { $0.toAttachment() }
+        event.bodyLocArgs = bodyLocArgs
+        event.bodyLocKey = bodyLocKey
+        event.category = category
+        event.contentAvailable = contentAvailable
+        event.group = group
+        event.icon = icon
+        event.notificationCount = notificationCount
+        event.notificationTimestamp = notificationTimestamp
+        event.sound = sound
+        event.subtitle = subtitle
+        event.tag = tag
+        event.threadIdentifier = threadIdentifier
+        event.titleLocArgs = titleLocArgs
+        event.titleLocKey = titleLocKey
         return event
     }
 }

--- a/ios/Classes/readers/events/PageViewReader.swift
+++ b/ios/Classes/readers/events/PageViewReader.swift
@@ -14,7 +14,7 @@ import SnowplowTracker
 
 struct PageViewReader: Decodable {
     let url: String
-    let title: String
+    let title: String?
     let referrer: String?
 }
 

--- a/ios/Classes/readers/messages/TrackDeepLinkReceivedMessageReader.swift
+++ b/ios/Classes/readers/messages/TrackDeepLinkReceivedMessageReader.swift
@@ -1,0 +1,23 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import Foundation
+import SnowplowTracker
+
+struct TrackDeepLinkReceivedMessageReader: Decodable {
+    let eventData: DeepLinkReceivedReader
+}
+
+extension TrackDeepLinkReceivedMessageReader {
+    func toDeepLinkReceived() -> DeepLinkReceived {
+        return eventData.toDeepLinkReceived()
+    }
+}

--- a/ios/Classes/readers/messages/TrackMessageNotificationMessageReader.swift
+++ b/ios/Classes/readers/messages/TrackMessageNotificationMessageReader.swift
@@ -1,0 +1,23 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import Foundation
+import SnowplowTracker
+
+struct TrackMessageNotificationMessageReader: Decodable {
+    let eventData: MessageNotificationReader
+}
+
+extension TrackMessageNotificationMessageReader {
+    func toMessageNotification() -> MessageNotification {
+        return eventData.toMessageNotification()
+    }
+}

--- a/ios/Tests/RunnerTests/DeepLinkReceivedReaderTests.swift
+++ b/ios/Tests/RunnerTests/DeepLinkReceivedReaderTests.swift
@@ -1,0 +1,60 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import XCTest
+@testable import snowplow_tracker
+
+class DeepLinkReceivedReaderTests: XCTestCase {
+
+    func testReaderDecodesRequiredUrl() throws {
+        let json = """
+        {"url": "https://example.com/path"}
+        """
+        let data = json.data(using: .utf8)!
+        let reader = try JSONDecoder().decode(DeepLinkReceivedReader.self, from: data)
+
+        XCTAssertEqual(reader.url, "https://example.com/path")
+        XCTAssertNil(reader.referrer)
+    }
+
+    func testReaderDecodesOptionalReferrer() throws {
+        let json = """
+        {"url": "https://example.com/path", "referrer": "https://referrer.example.com"}
+        """
+        let data = json.data(using: .utf8)!
+        let reader = try JSONDecoder().decode(DeepLinkReceivedReader.self, from: data)
+
+        XCTAssertEqual(reader.url, "https://example.com/path")
+        XCTAssertEqual(reader.referrer, "https://referrer.example.com")
+    }
+
+    func testToDeepLinkReceivedProducesEvent() throws {
+        let json = """
+        {"url": "https://example.com/path", "referrer": "https://referrer.example.com"}
+        """
+        let data = json.data(using: .utf8)!
+        let reader = try JSONDecoder().decode(DeepLinkReceivedReader.self, from: data)
+        let event = reader.toDeepLinkReceived()
+
+        XCTAssertNotNil(event)
+    }
+
+    func testToDeepLinkReceivedWithoutReferrer() throws {
+        let json = """
+        {"url": "https://example.com/path"}
+        """
+        let data = json.data(using: .utf8)!
+        let reader = try JSONDecoder().decode(DeepLinkReceivedReader.self, from: data)
+        let event = reader.toDeepLinkReceived()
+
+        XCTAssertNotNil(event)
+    }
+}

--- a/ios/Tests/RunnerTests/MessageNotificationReaderTests.swift
+++ b/ios/Tests/RunnerTests/MessageNotificationReaderTests.swift
@@ -1,0 +1,126 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import XCTest
+@testable import snowplow_tracker
+
+class MessageNotificationReaderTests: XCTestCase {
+
+    func testReaderDecodesRequiredFields() throws {
+        let json = """
+        {"title": "Test Title", "body": "Test Body", "trigger": "push"}
+        """
+        let data = json.data(using: .utf8)!
+        let reader = try JSONDecoder().decode(MessageNotificationReader.self, from: data)
+
+        XCTAssertEqual(reader.title, "Test Title")
+        XCTAssertEqual(reader.body, "Test Body")
+        XCTAssertEqual(reader.trigger, "push")
+    }
+
+    func testReaderDecodesOptionalFields() throws {
+        let json = """
+        {
+            "title": "Title",
+            "body": "Body",
+            "trigger": "calendar",
+            "action": "Open",
+            "badge": 3,
+            "categoryIdentifier": "cat1",
+            "launchImageName": "launch",
+            "notificationTimestamp": "2023-01-01T00:00:00Z",
+            "sound": "default",
+            "subtitle": "Subtitle",
+            "threadIdentifier": "thread1"
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let reader = try JSONDecoder().decode(MessageNotificationReader.self, from: data)
+
+        XCTAssertEqual(reader.action, "Open")
+        XCTAssertEqual(reader.badge, 3)
+        XCTAssertEqual(reader.categoryIdentifier, "cat1")
+        XCTAssertEqual(reader.launchImageName, "launch")
+        XCTAssertEqual(reader.notificationTimestamp, "2023-01-01T00:00:00Z")
+        XCTAssertEqual(reader.sound, "default")
+        XCTAssertEqual(reader.subtitle, "Subtitle")
+        XCTAssertEqual(reader.threadIdentifier, "thread1")
+    }
+
+    func testReaderNullsAbsentOptionalFields() throws {
+        let json = """
+        {"title": "Title", "body": "Body", "trigger": "push"}
+        """
+        let data = json.data(using: .utf8)!
+        let reader = try JSONDecoder().decode(MessageNotificationReader.self, from: data)
+
+        XCTAssertNil(reader.action)
+        XCTAssertNil(reader.badge)
+        XCTAssertNil(reader.categoryIdentifier)
+        XCTAssertNil(reader.launchImageName)
+        XCTAssertNil(reader.notificationTimestamp)
+        XCTAssertNil(reader.sound)
+        XCTAssertNil(reader.subtitle)
+        XCTAssertNil(reader.threadIdentifier)
+        XCTAssertNil(reader.attachments)
+    }
+
+    func testToMessageNotificationProducesEvent() throws {
+        let json = """
+        {"title": "Title", "body": "Body", "trigger": "push"}
+        """
+        let data = json.data(using: .utf8)!
+        let reader = try JSONDecoder().decode(MessageNotificationReader.self, from: data)
+        let event = reader.toMessageNotification()
+
+        XCTAssertNotNil(event)
+    }
+
+    func testToMessageNotificationWithAllOptionalFields() throws {
+        let json = """
+        {
+            "title": "Title",
+            "body": "Body",
+            "trigger": "timeInterval",
+            "action": "Open",
+            "badge": 2,
+            "categoryIdentifier": "cat1",
+            "launchImageName": "launch",
+            "notificationTimestamp": "2023-01-01T00:00:00Z",
+            "sound": "default",
+            "subtitle": "Subtitle",
+            "threadIdentifier": "thread1",
+            "attachments": [
+                {"identifier": "att1", "type": "image/png", "url": "https://example.com/img.png"}
+            ]
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let reader = try JSONDecoder().decode(MessageNotificationReader.self, from: data)
+        let event = reader.toMessageNotification()
+
+        XCTAssertNotNil(event)
+        XCTAssertEqual(reader.attachments?.count, 1)
+        XCTAssertEqual(reader.attachments?.first?.identifier, "att1")
+    }
+
+    func testAllTriggerValuesProduceEvent() throws {
+        for triggerStr in ["push", "calendar", "timeInterval", "location"] {
+            let json = """
+            {"title": "Title", "body": "Body", "trigger": "\(triggerStr)"}
+            """
+            let data = json.data(using: .utf8)!
+            let reader = try JSONDecoder().decode(MessageNotificationReader.self, from: data)
+            let event = reader.toMessageNotification()
+            XCTAssertNotNil(event, "Event should not be nil for trigger: \(triggerStr)")
+        }
+    }
+}

--- a/ios/Tests/RunnerTests/MessageNotificationReaderTests.swift
+++ b/ios/Tests/RunnerTests/MessageNotificationReaderTests.swift
@@ -33,26 +33,40 @@ class MessageNotificationReaderTests: XCTestCase {
             "body": "Body",
             "trigger": "calendar",
             "action": "Open",
-            "badge": 3,
-            "categoryIdentifier": "cat1",
-            "launchImageName": "launch",
+            "bodyLocArgs": ["bodyArg"],
+            "bodyLocKey": "bodyKey",
+            "category": "cat1",
+            "contentAvailable": true,
+            "group": "group1",
+            "icon": "icon1",
+            "notificationCount": 5,
             "notificationTimestamp": "2023-01-01T00:00:00Z",
             "sound": "default",
             "subtitle": "Subtitle",
-            "threadIdentifier": "thread1"
+            "tag": "tag1",
+            "threadIdentifier": "thread1",
+            "titleLocArgs": ["titleArg"],
+            "titleLocKey": "titleKey"
         }
         """
         let data = json.data(using: .utf8)!
         let reader = try JSONDecoder().decode(MessageNotificationReader.self, from: data)
 
         XCTAssertEqual(reader.action, "Open")
-        XCTAssertEqual(reader.badge, 3)
-        XCTAssertEqual(reader.categoryIdentifier, "cat1")
-        XCTAssertEqual(reader.launchImageName, "launch")
+        XCTAssertEqual(reader.bodyLocArgs, ["bodyArg"])
+        XCTAssertEqual(reader.bodyLocKey, "bodyKey")
+        XCTAssertEqual(reader.category, "cat1")
+        XCTAssertEqual(reader.contentAvailable, true)
+        XCTAssertEqual(reader.group, "group1")
+        XCTAssertEqual(reader.icon, "icon1")
+        XCTAssertEqual(reader.notificationCount, 5)
         XCTAssertEqual(reader.notificationTimestamp, "2023-01-01T00:00:00Z")
         XCTAssertEqual(reader.sound, "default")
         XCTAssertEqual(reader.subtitle, "Subtitle")
+        XCTAssertEqual(reader.tag, "tag1")
         XCTAssertEqual(reader.threadIdentifier, "thread1")
+        XCTAssertEqual(reader.titleLocArgs, ["titleArg"])
+        XCTAssertEqual(reader.titleLocKey, "titleKey")
     }
 
     func testReaderNullsAbsentOptionalFields() throws {
@@ -63,14 +77,21 @@ class MessageNotificationReaderTests: XCTestCase {
         let reader = try JSONDecoder().decode(MessageNotificationReader.self, from: data)
 
         XCTAssertNil(reader.action)
-        XCTAssertNil(reader.badge)
-        XCTAssertNil(reader.categoryIdentifier)
-        XCTAssertNil(reader.launchImageName)
+        XCTAssertNil(reader.attachments)
+        XCTAssertNil(reader.bodyLocArgs)
+        XCTAssertNil(reader.bodyLocKey)
+        XCTAssertNil(reader.category)
+        XCTAssertNil(reader.contentAvailable)
+        XCTAssertNil(reader.group)
+        XCTAssertNil(reader.icon)
+        XCTAssertNil(reader.notificationCount)
         XCTAssertNil(reader.notificationTimestamp)
         XCTAssertNil(reader.sound)
         XCTAssertNil(reader.subtitle)
+        XCTAssertNil(reader.tag)
         XCTAssertNil(reader.threadIdentifier)
-        XCTAssertNil(reader.attachments)
+        XCTAssertNil(reader.titleLocArgs)
+        XCTAssertNil(reader.titleLocKey)
     }
 
     func testToMessageNotificationProducesEvent() throws {
@@ -91,9 +112,7 @@ class MessageNotificationReaderTests: XCTestCase {
             "body": "Body",
             "trigger": "timeInterval",
             "action": "Open",
-            "badge": 2,
-            "categoryIdentifier": "cat1",
-            "launchImageName": "launch",
+            "category": "cat1",
             "notificationTimestamp": "2023-01-01T00:00:00Z",
             "sound": "default",
             "subtitle": "Subtitle",

--- a/ios/snowplow_tracker.podspec
+++ b/ios/snowplow_tracker.podspec
@@ -21,4 +21,8 @@ A package for tracking Snowplow events in Flutter apps.
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*.swift'
+  end
 end

--- a/lib/events/deep_link_received.dart
+++ b/lib/events/deep_link_received.dart
@@ -1,0 +1,47 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import 'package:flutter/foundation.dart';
+
+import 'package:snowplow_tracker/events/event.dart';
+
+/// Event to track a deep link received in the app (mobile only).
+///
+/// {@category Tracking events}
+@immutable
+class DeepLinkReceived implements Event {
+  /// The URL of the deep link.
+  final String url;
+
+  /// The referrer URL of the deep link.
+  final String? referrer;
+
+  const DeepLinkReceived({required this.url, this.referrer});
+
+  DeepLinkReceived.fromMap(Map<String, Object?> map)
+      : url = map['url'] as String,
+        referrer = map['referrer'] as String?;
+
+  @override
+  String endpoint() {
+    return 'trackDeepLinkReceived';
+  }
+
+  @override
+  Map<String, Object?> toMap() {
+    final data = <String, Object?>{
+      'url': url,
+      'referrer': referrer,
+    };
+    data.removeWhere((key, value) => value == null);
+    return data;
+  }
+}

--- a/lib/events/message_notification.dart
+++ b/lib/events/message_notification.dart
@@ -34,43 +34,80 @@ class MessageNotification implements Event {
   /// The action associated with the notification.
   final String? action;
 
-  /// The badge count of the application.
-  final int? badge;
+  /// Attachments added to the notification (they can be part of the data
+  /// object).
+  final List<MessageNotificationAttachment>? attachments;
 
-  /// The category identifier of the notification.
-  final String? categoryIdentifier;
+  /// Variable string values to be used in place of the format specifiers in
+  /// [bodyLocKey] to localize the body text to the user's current
+  /// localization.
+  final List<String>? bodyLocArgs;
 
-  /// The name of the launch image used when the app is launched.
-  final String? launchImageName;
+  /// The key to the body string in the app's string resources to use to
+  /// localize the body text to the user's current localization.
+  final String? bodyLocKey;
 
-  /// The date and time the notification was sent.
+  /// The category associated with the notification.
+  final String? category;
+
+  /// Whether the app is notified of the delivery of the notification while in
+  /// the foreground or background (iOS only).
+  final bool? contentAvailable;
+
+  /// The group which this notification is part of.
+  final String? group;
+
+  /// The icon associated with the notification (Android only).
+  final String? icon;
+
+  /// The number of items this notification represents.
+  final int? notificationCount;
+
+  /// The time when the notification was delivered.
   final String? notificationTimestamp;
 
-  /// The sound of the notification.
+  /// The sound played when the device receives the notification.
   final String? sound;
 
-  /// The subtitle of the notification.
+  /// The notification's subtitle.
   final String? subtitle;
 
-  /// The thread identifier of the notification.
+  /// An identifier for the notification, used to replace or group
+  /// notifications (Android only).
+  final String? tag;
+
+  /// The thread identifier the notification belongs to (iOS only).
   final String? threadIdentifier;
 
-  /// The attachments included in the notification.
-  final List<MessageNotificationAttachment>? attachments;
+  /// Variable string values to be used in place of the format specifiers in
+  /// [titleLocKey] to localize the title text to the user's current
+  /// localization.
+  final List<String>? titleLocArgs;
+
+  /// The key to the title string in the app's string resources to use to
+  /// localize the title text to the user's current localization.
+  final String? titleLocKey;
 
   const MessageNotification({
     required this.title,
     required this.body,
     required this.trigger,
     this.action,
-    this.badge,
-    this.categoryIdentifier,
-    this.launchImageName,
+    this.attachments,
+    this.bodyLocArgs,
+    this.bodyLocKey,
+    this.category,
+    this.contentAvailable,
+    this.group,
+    this.icon,
+    this.notificationCount,
     this.notificationTimestamp,
     this.sound,
     this.subtitle,
+    this.tag,
     this.threadIdentifier,
-    this.attachments,
+    this.titleLocArgs,
+    this.titleLocKey,
   });
 
   @override
@@ -85,14 +122,21 @@ class MessageNotification implements Event {
       'body': body,
       'trigger': trigger,
       'action': action,
-      'badge': badge,
-      'categoryIdentifier': categoryIdentifier,
-      'launchImageName': launchImageName,
+      'attachments': attachments?.map((a) => a.toMap()).toList(),
+      'bodyLocArgs': bodyLocArgs,
+      'bodyLocKey': bodyLocKey,
+      'category': category,
+      'contentAvailable': contentAvailable,
+      'group': group,
+      'icon': icon,
+      'notificationCount': notificationCount,
       'notificationTimestamp': notificationTimestamp,
       'sound': sound,
       'subtitle': subtitle,
+      'tag': tag,
       'threadIdentifier': threadIdentifier,
-      'attachments': attachments?.map((a) => a.toMap()).toList(),
+      'titleLocArgs': titleLocArgs,
+      'titleLocKey': titleLocKey,
     };
     data.removeWhere((key, value) => value == null);
     return data;

--- a/lib/events/message_notification.dart
+++ b/lib/events/message_notification.dart
@@ -1,0 +1,100 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import 'package:flutter/foundation.dart';
+
+import 'package:snowplow_tracker/events/event.dart';
+import 'package:snowplow_tracker/events/message_notification_attachment.dart';
+
+/// Event to track a push notification (mobile only).
+///
+/// The [trigger] field indicates the trigger type: one of 'push', 'calendar',
+/// 'timeInterval', or 'location'.
+///
+/// {@category Tracking events}
+@immutable
+class MessageNotification implements Event {
+  /// The notification title.
+  final String title;
+
+  /// The notification body.
+  final String body;
+
+  /// The trigger that caused the notification to be delivered.
+  final String trigger;
+
+  /// The action associated with the notification.
+  final String? action;
+
+  /// The badge count of the application.
+  final int? badge;
+
+  /// The category identifier of the notification.
+  final String? categoryIdentifier;
+
+  /// The name of the launch image used when the app is launched.
+  final String? launchImageName;
+
+  /// The date and time the notification was sent.
+  final String? notificationTimestamp;
+
+  /// The sound of the notification.
+  final String? sound;
+
+  /// The subtitle of the notification.
+  final String? subtitle;
+
+  /// The thread identifier of the notification.
+  final String? threadIdentifier;
+
+  /// The attachments included in the notification.
+  final List<MessageNotificationAttachment>? attachments;
+
+  const MessageNotification({
+    required this.title,
+    required this.body,
+    required this.trigger,
+    this.action,
+    this.badge,
+    this.categoryIdentifier,
+    this.launchImageName,
+    this.notificationTimestamp,
+    this.sound,
+    this.subtitle,
+    this.threadIdentifier,
+    this.attachments,
+  });
+
+  @override
+  String endpoint() {
+    return 'trackMessageNotification';
+  }
+
+  @override
+  Map<String, Object?> toMap() {
+    final data = <String, Object?>{
+      'title': title,
+      'body': body,
+      'trigger': trigger,
+      'action': action,
+      'badge': badge,
+      'categoryIdentifier': categoryIdentifier,
+      'launchImageName': launchImageName,
+      'notificationTimestamp': notificationTimestamp,
+      'sound': sound,
+      'subtitle': subtitle,
+      'threadIdentifier': threadIdentifier,
+      'attachments': attachments?.map((a) => a.toMap()).toList(),
+    };
+    data.removeWhere((key, value) => value == null);
+    return data;
+  }
+}

--- a/lib/events/message_notification_attachment.dart
+++ b/lib/events/message_notification_attachment.dart
@@ -1,0 +1,41 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import 'package:flutter/foundation.dart';
+
+/// Attachment included in a push notification (used with [MessageNotification]).
+///
+/// {@category Tracking events}
+@immutable
+class MessageNotificationAttachment {
+  /// The attachment identifier.
+  final String identifier;
+
+  /// The attachment MIME type.
+  final String type;
+
+  /// The attachment URL.
+  final String url;
+
+  const MessageNotificationAttachment({
+    required this.identifier,
+    required this.type,
+    required this.url,
+  });
+
+  Map<String, Object?> toMap() {
+    return <String, Object?>{
+      'identifier': identifier,
+      'type': type,
+      'url': url,
+    };
+  }
+}

--- a/lib/snowplow_tracker.dart
+++ b/lib/snowplow_tracker.dart
@@ -59,6 +59,9 @@ export 'events/media_ready_event.dart';
 export 'events/media_seek_end_event.dart';
 export 'events/media_seek_start_event.dart';
 export 'events/media_volume_change_event.dart';
+export 'events/deep_link_received.dart';
+export 'events/message_notification.dart';
+export 'events/message_notification_attachment.dart';
 
 export 'entities/media_ad_break_entity.dart';
 export 'entities/media_ad_entity.dart';

--- a/test/events/deep_link_received_test.dart
+++ b/test/events/deep_link_received_test.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snowplow_tracker/events/deep_link_received.dart';
+
+void main() {
+  test('DeepLinkReceived endpoint returns correct value', () {
+    const event = DeepLinkReceived(url: 'https://example.com/path');
+    expect(event.endpoint(), equals('trackDeepLinkReceived'));
+  });
+
+  test('DeepLinkReceived toMap includes required url field', () {
+    const event = DeepLinkReceived(url: 'https://example.com/path');
+    final map = event.toMap();
+
+    expect(map['url'], equals('https://example.com/path'));
+  });
+
+  test('DeepLinkReceived toMap omits null referrer', () {
+    const event = DeepLinkReceived(url: 'https://example.com/path');
+    final map = event.toMap();
+
+    expect(map.containsKey('referrer'), isFalse);
+  });
+
+  test('DeepLinkReceived toMap includes referrer when set', () {
+    const event = DeepLinkReceived(
+      url: 'https://example.com/path',
+      referrer: 'https://referrer.example.com',
+    );
+    final map = event.toMap();
+
+    expect(map['url'], equals('https://example.com/path'));
+    expect(map['referrer'], equals('https://referrer.example.com'));
+  });
+
+  test('DeepLinkReceived fromMap round-trips all fields', () {
+    final map = {
+      'url': 'https://example.com/path',
+      'referrer': 'https://referrer.example.com',
+    };
+    final event = DeepLinkReceived.fromMap(map);
+    final result = event.toMap();
+
+    expect(result['url'], equals('https://example.com/path'));
+    expect(result['referrer'], equals('https://referrer.example.com'));
+  });
+
+  test('DeepLinkReceived fromMap handles missing optional referrer', () {
+    final map = {'url': 'https://example.com/path'};
+    final event = DeepLinkReceived.fromMap(map);
+    final result = event.toMap();
+
+    expect(result['url'], equals('https://example.com/path'));
+    expect(result.containsKey('referrer'), isFalse);
+  });
+}

--- a/test/events/message_notification_test.dart
+++ b/test/events/message_notification_test.dart
@@ -1,0 +1,102 @@
+// Copyright (c) 2022-present Snowplow Analytics Ltd. All rights reserved.
+//
+// This program is licensed to you under the Apache License Version 2.0,
+// and you may not use this file except in compliance with the Apache License Version 2.0.
+// You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the Apache License Version 2.0 is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:snowplow_tracker/events/message_notification.dart';
+import 'package:snowplow_tracker/events/message_notification_attachment.dart';
+
+void main() {
+  test('MessageNotification endpoint returns correct value', () {
+    const event =
+        MessageNotification(title: 'Title', body: 'Body', trigger: 'push');
+    expect(event.endpoint(), equals('trackMessageNotification'));
+  });
+
+  test('MessageNotification toMap includes required fields', () {
+    const event =
+        MessageNotification(title: 'Title', body: 'Body', trigger: 'push');
+    final map = event.toMap();
+
+    expect(map['title'], equals('Title'));
+    expect(map['body'], equals('Body'));
+    expect(map['trigger'], equals('push'));
+  });
+
+  test('MessageNotification toMap omits null optional fields', () {
+    const event =
+        MessageNotification(title: 'Title', body: 'Body', trigger: 'push');
+    final map = event.toMap();
+
+    expect(map.containsKey('action'), isFalse);
+    expect(map.containsKey('badge'), isFalse);
+    expect(map.containsKey('categoryIdentifier'), isFalse);
+    expect(map.containsKey('launchImageName'), isFalse);
+    expect(map.containsKey('notificationTimestamp'), isFalse);
+    expect(map.containsKey('sound'), isFalse);
+    expect(map.containsKey('subtitle'), isFalse);
+    expect(map.containsKey('threadIdentifier'), isFalse);
+    expect(map.containsKey('attachments'), isFalse);
+  });
+
+  test('MessageNotification toMap includes all optional fields when set', () {
+    const attachment = MessageNotificationAttachment(
+      identifier: 'att1',
+      type: 'image/png',
+      url: 'https://example.com/image.png',
+    );
+    const event = MessageNotification(
+      title: 'Title',
+      body: 'Body',
+      trigger: 'calendar',
+      action: 'Open',
+      badge: 3,
+      categoryIdentifier: 'cat1',
+      launchImageName: 'launch',
+      notificationTimestamp: '2023-01-01T00:00:00Z',
+      sound: 'default',
+      subtitle: 'Subtitle',
+      threadIdentifier: 'thread1',
+      attachments: [attachment],
+    );
+    final map = event.toMap();
+
+    expect(map['title'], equals('Title'));
+    expect(map['body'], equals('Body'));
+    expect(map['trigger'], equals('calendar'));
+    expect(map['action'], equals('Open'));
+    expect(map['badge'], equals(3));
+    expect(map['categoryIdentifier'], equals('cat1'));
+    expect(map['launchImageName'], equals('launch'));
+    expect(map['notificationTimestamp'], equals('2023-01-01T00:00:00Z'));
+    expect(map['sound'], equals('default'));
+    expect(map['subtitle'], equals('Subtitle'));
+    expect(map['threadIdentifier'], equals('thread1'));
+
+    final attachments = map['attachments'] as List;
+    expect(attachments.length, equals(1));
+    expect(attachments[0]['identifier'], equals('att1'));
+    expect(attachments[0]['type'], equals('image/png'));
+    expect(attachments[0]['url'], equals('https://example.com/image.png'));
+  });
+
+  test('MessageNotificationAttachment toMap includes all fields', () {
+    const attachment = MessageNotificationAttachment(
+      identifier: 'att1',
+      type: 'image/png',
+      url: 'https://example.com/image.png',
+    );
+    final map = attachment.toMap();
+
+    expect(map['identifier'], equals('att1'));
+    expect(map['type'], equals('image/png'));
+    expect(map['url'], equals('https://example.com/image.png'));
+  });
+}

--- a/test/events/message_notification_test.dart
+++ b/test/events/message_notification_test.dart
@@ -36,14 +36,21 @@ void main() {
     final map = event.toMap();
 
     expect(map.containsKey('action'), isFalse);
-    expect(map.containsKey('badge'), isFalse);
-    expect(map.containsKey('categoryIdentifier'), isFalse);
-    expect(map.containsKey('launchImageName'), isFalse);
+    expect(map.containsKey('attachments'), isFalse);
+    expect(map.containsKey('bodyLocArgs'), isFalse);
+    expect(map.containsKey('bodyLocKey'), isFalse);
+    expect(map.containsKey('category'), isFalse);
+    expect(map.containsKey('contentAvailable'), isFalse);
+    expect(map.containsKey('group'), isFalse);
+    expect(map.containsKey('icon'), isFalse);
+    expect(map.containsKey('notificationCount'), isFalse);
     expect(map.containsKey('notificationTimestamp'), isFalse);
     expect(map.containsKey('sound'), isFalse);
     expect(map.containsKey('subtitle'), isFalse);
+    expect(map.containsKey('tag'), isFalse);
     expect(map.containsKey('threadIdentifier'), isFalse);
-    expect(map.containsKey('attachments'), isFalse);
+    expect(map.containsKey('titleLocArgs'), isFalse);
+    expect(map.containsKey('titleLocKey'), isFalse);
   });
 
   test('MessageNotification toMap includes all optional fields when set', () {
@@ -57,14 +64,21 @@ void main() {
       body: 'Body',
       trigger: 'calendar',
       action: 'Open',
-      badge: 3,
-      categoryIdentifier: 'cat1',
-      launchImageName: 'launch',
+      attachments: [attachment],
+      bodyLocArgs: ['bodyArg'],
+      bodyLocKey: 'bodyKey',
+      category: 'cat1',
+      contentAvailable: true,
+      group: 'group1',
+      icon: 'icon1',
+      notificationCount: 5,
       notificationTimestamp: '2023-01-01T00:00:00Z',
       sound: 'default',
       subtitle: 'Subtitle',
+      tag: 'tag1',
       threadIdentifier: 'thread1',
-      attachments: [attachment],
+      titleLocArgs: ['titleArg'],
+      titleLocKey: 'titleKey',
     );
     final map = event.toMap();
 
@@ -72,13 +86,20 @@ void main() {
     expect(map['body'], equals('Body'));
     expect(map['trigger'], equals('calendar'));
     expect(map['action'], equals('Open'));
-    expect(map['badge'], equals(3));
-    expect(map['categoryIdentifier'], equals('cat1'));
-    expect(map['launchImageName'], equals('launch'));
+    expect(map['bodyLocArgs'], equals(['bodyArg']));
+    expect(map['bodyLocKey'], equals('bodyKey'));
+    expect(map['category'], equals('cat1'));
+    expect(map['contentAvailable'], equals(true));
+    expect(map['group'], equals('group1'));
+    expect(map['icon'], equals('icon1'));
+    expect(map['notificationCount'], equals(5));
     expect(map['notificationTimestamp'], equals('2023-01-01T00:00:00Z'));
     expect(map['sound'], equals('default'));
     expect(map['subtitle'], equals('Subtitle'));
+    expect(map['tag'], equals('tag1'));
     expect(map['threadIdentifier'], equals('thread1'));
+    expect(map['titleLocArgs'], equals(['titleArg']));
+    expect(map['titleLocKey'], equals('titleKey'));
 
     final attachments = map['attachments'] as List;
     expect(attachments.length, equals(1));


### PR DESCRIPTION
## What

Adds `DeepLinkReceived` and `MessageNotification` event tracking (mobile) to the Flutter tracker, across the Dart API and the native Android (Kotlin) and iOS (Swift) layers, with unit and integration tests.

## Events

- **`DeepLinkReceived`** — `url` (required), `referrer` (optional). Schema `iglu:com.snowplowanalytics.mobile/deep_link_received/jsonschema/1-0-0`.
- **`MessageNotification`** — `title`, `body`, `trigger` (required) plus the optional schema fields: `action`, `attachments`, `bodyLocArgs`, `bodyLocKey`, `category`, `contentAvailable`, `group`, `icon`, `notificationCount`, `notificationTimestamp`, `sound`, `subtitle`, `tag`, `threadIdentifier`, `titleLocArgs`, `titleLocKey`. Schema `iglu:com.snowplowanalytics.mobile/message_notification/jsonschema/1-0-0`.

## Fixes included (all scoped to this feature)

1. **Schema alignment** — the initial `MessageNotification` implementation exposed fields that don't exist in the schema or the native SDKs (`badge`, `categoryIdentifier`, `launchImageName`) and called a non-existent iOS `thread(...)` builder, which broke the iOS Swift build and the Android Kotlin compile. Replaced with the real optional fields (verified against `SnowplowTracker` 6.2.x and `snowplow-android-tracker` 6.2.x, matching the React Native tracker).
2. **iOS `PageViewReader.title`** made optional to match the Dart model and the Android reader — tracking a mobile page view without a title previously failed to decode on iOS.
3. **Integration-test emitter race** — the mobile page-view test now awaits delivery to Micro, so its event can't leak into the following deep-link test's window (Android's emitter flushes asynchronously).

## Testing

- `flutter analyze`, `dart format --set-exit-if-changed .`, and `flutter test` verified locally with the exact CI toolchain (Flutter 3.32.0 / Dart 3.8.0).

## Note

Android CI depends on #84, which skips a pre-existing flaky test (`configuration_test.dart` → "sets all platform context properties overrides") that is unrelated to this feature. Merge #84 first (or rebase this branch on it) for a reliably green Android job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
