### PR TITLE
chore: update native trackers to latest (Android 6.4, iOS 6.2.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Modernise the Android plugin and example app builds: migrate to the Kotlin Gradle DSL and align the toolchain with the native tracker (Android Gradle Plugin 8.13, Kotlin 2.2, Gradle 8.13, `compileSdk` 35, Java/Kotlin JVM target 17)
 * Add Swift Package Manager support for the iOS plugin while keeping CocoaPods compatibility
 * Switch the iOS example app from CocoaPods to Swift Package Manager
+* Update the native trackers to their latest releases (Android tracker 6.4, iOS tracker 6.2.5)
 * **Breaking:** raise the minimum iOS deployment target to 13.0 (was 11.0)
 
 # 0.10.0

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -72,7 +72,7 @@ kotlin {
 }
 
 dependencies {
-    implementation("com.snowplowanalytics:snowplow-android-tracker:6.2.+")
+    implementation("com.snowplowanalytics:snowplow-android-tracker:6.4.+")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.0.0")

--- a/ios/snowplow_tracker.podspec
+++ b/ios/snowplow_tracker.podspec
@@ -15,7 +15,7 @@ A package for tracking Snowplow events in Flutter apps.
   s.source           = { :path => '.' }
   s.source_files = 'snowplow_tracker/Sources/snowplow_tracker/**/*'
   s.dependency 'Flutter'
-  s.dependency 'SnowplowTracker', '~> 6.2.2'
+  s.dependency 'SnowplowTracker', '~> 6.2.5'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/snowplow_tracker/Package.swift
+++ b/ios/snowplow_tracker/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "snowplow-tracker", targets: ["snowplow_tracker"])
     ],
     dependencies: [
-        .package(url: "https://github.com/snowplow/snowplow-ios-tracker.git", from: "6.2.2")
+        .package(url: "https://github.com/snowplow/snowplow-ios-tracker.git", from: "6.2.5")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Updates the pinned native tracker versions to their latest releases, floating within the latest minor line.

## Changes
| Tracker | Before | After | Resolves |
|---|---|---|---|
| Android (`snowplow-android-tracker`) | `6.2.+` | `6.4.+` | 6.4.0 |
| iOS SPM (`snowplow-ios-tracker`) | `from: 6.2.2` | `from: 6.2.5` | 6.2.5 |
| iOS CocoaPods (`SnowplowTracker`) | `~> 6.2.2` | `~> 6.2.5` | 6.2.5 |

## Notes
- Android tracker 6.3.0 already aligned to `targetSdk` 35 / Gradle 8.13 — matching the toolchain adopted in #88 (0.11.0). No breaking API changes across 6.2 → 6.4.
- The example app's committed `Package.resolved` was already at iOS tracker 6.2.5; this bump makes the `Package.swift` manifest match.
- CHANGELOG updated under the (unreleased) 0.11.0 entry.

## Verification
- ✅ Android: `flutter build apk --debug` builds; dependency resolves `6.4.+ -> 6.4.0`
- ✅ iOS (SPM): `flutter build ios --debug --no-codesign --simulator` → `Runner.app`; `Package.resolved` shows 6.2.5
- ✅ `flutter analyze` clean; 62 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
